### PR TITLE
Remove EventLog dependency and route errors through Serilog

### DIFF
--- a/RFiDGear.Tests/MainWindowViewModelTests.cs
+++ b/RFiDGear.Tests/MainWindowViewModelTests.cs
@@ -203,7 +203,7 @@ namespace RFiDGear.Tests
 
     internal class FakeAppStartupInitializer : IAppStartupInitializer
     {
-        public AppStartupContext Initialize() => new AppStartupContext(null, new Mutex(), Array.Empty<string>());
+        public AppStartupContext Initialize() => new AppStartupContext(new Mutex(), Array.Empty<string>());
     }
 
     internal class FakeTimerFactory : ITimerFactory

--- a/RFiDGear.Tests/TaskExecutionSupportTests.cs
+++ b/RFiDGear.Tests/TaskExecutionSupportTests.cs
@@ -61,7 +61,7 @@ namespace RFiDGear.Tests
         {
             using var mutex = new Mutex();
 #pragma warning disable CS8625 // Intentional null to validate default handling
-            var context = new AppStartupContext(null, mutex, (string[])null!);
+            var context = new AppStartupContext(mutex, (string[])null!);
 #pragma warning restore CS8625
 
             Assert.NotNull(context.Arguments);
@@ -72,7 +72,7 @@ namespace RFiDGear.Tests
         public void Constructor_ThrowsWhenMutexIsNull()
         {
 #pragma warning disable CS8625 // Intentional null to validate guard clause
-            Assert.Throws<ArgumentNullException>(() => new AppStartupContext(null, null!, Array.Empty<string>()));
+            Assert.Throws<ArgumentNullException>(() => new AppStartupContext(null!, Array.Empty<string>()));
 #pragma warning restore CS8625
         }
     }

--- a/RFiDGear/Infrastructure/ReaderProviders/ElatecNetProvider.cs
+++ b/RFiDGear/Infrastructure/ReaderProviders/ElatecNetProvider.cs
@@ -1,7 +1,6 @@
 ﻿//using Elatec.NET.Model;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -12,6 +11,7 @@ using Elatec.NET;
 using RFiDGear.Models;
 using RFiDGear.Infrastructure.Tasks;
 using Elatec.NET.Cards.Mifare;
+using Serilog;
 
 namespace RFiDGear.Infrastructure.ReaderProviders
 {
@@ -20,9 +20,6 @@ namespace RFiDGear.Infrastructure.ReaderProviders
         private TWN4ReaderDevice readerDevice;
         private readonly byte DESFIRE_AUTHMODE_COMPATIBLE = 0;
         private readonly byte DESFIRE_AUTHMODE_EV1 = 1;
-
-        private readonly EventLog eventLog
-            = new EventLog("Application", ".", Assembly.GetEntryAssembly().GetName().Name);
 
         private GenericChipModel hfTag;
         private GenericChipModel lfTag;
@@ -59,7 +56,7 @@ namespace RFiDGear.Infrastructure.ReaderProviders
             }
             catch (Exception e)
             {
-                eventLog.WriteEntry(e.Message, EventLogEntryType.Error);
+                Log.ForContext<ElatecNetProvider>().Error(e, "Elatec operation failed.");
             }
         }
 
@@ -187,7 +184,7 @@ namespace RFiDGear.Infrastructure.ReaderProviders
             }
             catch (Exception e)
             {
-                eventLog.WriteEntry(e.Message, EventLogEntryType.Error);
+                Log.ForContext<ElatecNetProvider>().Error(e, "Elatec operation failed.");
 
                 return ERROR.TransportError;
             }
@@ -430,7 +427,7 @@ namespace RFiDGear.Infrastructure.ReaderProviders
             }
             catch (Exception e)
             {
-                eventLog.WriteEntry($"Unable to read DESFire key version: {e.Message}", EventLogEntryType.Error);
+                Log.ForContext<ElatecNetProvider>().Error(e, "Unable to read DESFire key version.");
                 throw;
             }
         }
@@ -916,7 +913,7 @@ namespace RFiDGear.Infrastructure.ReaderProviders
                     }
                     catch (Exception e)
                     {
-                        eventLog.WriteEntry($"Unable to read DESFire key settings after authentication: {e.Message}", EventLogEntryType.Warning);
+                        Log.ForContext<ElatecNetProvider>().Warning(e, "Unable to read DESFire key settings after authentication.");
                     }
 
                     var configuredKeyType = EncryptionType;
@@ -934,7 +931,7 @@ namespace RFiDGear.Infrastructure.ReaderProviders
 
                     foreach (var warning in resolvedSettings.Warnings)
                     {
-                        eventLog.WriteEntry(warning, EventLogEntryType.Warning);
+                        Log.ForContext<ElatecNetProvider>().Warning("{WarningMessage}", warning);
                     }
 
                     MaxNumberOfAppKeys = resolvedSettings.KeyCount;
@@ -1259,7 +1256,7 @@ namespace RFiDGear.Infrastructure.ReaderProviders
                 }
                 catch (Exception e)
                 {
-                    eventLog.WriteEntry(e.Message, EventLogEntryType.Error);
+                    Log.ForContext<ElatecNetProvider>().Error(e, "Elatec operation failed.");
                     return ERROR.TransportError;
                 }
 
@@ -1384,7 +1381,7 @@ namespace RFiDGear.Infrastructure.ReaderProviders
             }
             catch (Exception e)
             {
-                eventLog.WriteEntry(e.Message, EventLogEntryType.Error);
+                Log.ForContext<ElatecNetProvider>().Error(e, "Elatec operation failed.");
                 return ERROR.TransportError;
             }
         }
@@ -1406,7 +1403,7 @@ namespace RFiDGear.Infrastructure.ReaderProviders
             }
             catch (Exception e)
             {
-                eventLog.WriteEntry(e.Message, EventLogEntryType.Error);
+                Log.ForContext<ElatecNetProvider>().Error(e, "Elatec operation failed.");
                 return ERROR.AuthFailure;
             }
 

--- a/RFiDGear/Infrastructure/ReaderProviders/LibLogicalAccessProvider.cs
+++ b/RFiDGear/Infrastructure/ReaderProviders/LibLogicalAccessProvider.cs
@@ -9,13 +9,12 @@ using RFiDGear.Models;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Diagnostics;
-using System.Reflection;
 using System.Linq;
 using System.Globalization;
 using RFiDGear.Infrastructure.Tasks;
 using RFiDGear.Infrastructure.AccessControl;
 using RFiDGear.Infrastructure.FileAccess;
+using Serilog;
 
 namespace RFiDGear.Infrastructure.ReaderProviders
 {
@@ -28,7 +27,6 @@ namespace RFiDGear.Infrastructure.ReaderProviders
     public class LibLogicalAccessProvider : ReaderDevice, IDisposable
     {
         // global (cross-class) Instances go here ->
-        private readonly EventLog eventLog = new EventLog("Application", ".", Assembly.GetEntryAssembly().GetName().Name);
         private readonly ProjectManager projectManager = new ProjectManager();
         private ReaderProvider readerProvider;
         private ReaderUnit readerUnit;
@@ -54,7 +52,7 @@ namespace RFiDGear.Infrastructure.ReaderProviders
             }
             catch (Exception e)
             {
-                eventLog.WriteEntry(e.Message, EventLogEntryType.Error);
+                Log.ForContext<LibLogicalAccessProvider>().Error(e, "LibLogicalAccess operation failed.");
             }
         }
 
@@ -96,7 +94,7 @@ namespace RFiDGear.Infrastructure.ReaderProviders
             }
             catch (Exception e)
             {
-                eventLog.WriteEntry(e.Message, EventLogEntryType.Error);
+                Log.ForContext<LibLogicalAccessProvider>().Error(e, "LibLogicalAccess operation failed.");
             }
         }
 
@@ -187,7 +185,7 @@ namespace RFiDGear.Infrastructure.ReaderProviders
                         }
                         catch (Exception e)
                         {
-                            eventLog.WriteEntry(e.Message, EventLogEntryType.Error);
+                            Log.ForContext<LibLogicalAccessProvider>().Error(e, "LibLogicalAccess operation failed.");
 
                             return ERROR.TransportError;
                         }
@@ -201,7 +199,7 @@ namespace RFiDGear.Infrastructure.ReaderProviders
                 if (readerProvider != null)
                     readerProvider.release();
 
-                eventLog.WriteEntry(e.Message, EventLogEntryType.Error);
+                Log.ForContext<LibLogicalAccessProvider>().Error(e, "LibLogicalAccess operation failed.");
 
                 return ERROR.TransportError;
             }
@@ -326,7 +324,7 @@ namespace RFiDGear.Infrastructure.ReaderProviders
             }
             catch (Exception e)
             {
-                eventLog.WriteEntry(e.Message, EventLogEntryType.Error);
+                Log.ForContext<LibLogicalAccessProvider>().Error(e, "LibLogicalAccess operation failed.");
                 return ERROR.AuthFailure;
             }
         }
@@ -413,7 +411,7 @@ namespace RFiDGear.Infrastructure.ReaderProviders
             }
             catch (Exception e)
             {
-                eventLog.WriteEntry(e.Message, EventLogEntryType.Error);
+                Log.ForContext<LibLogicalAccessProvider>().Error(e, "LibLogicalAccess operation failed.");
 
                 return ERROR.TransportError;
             }
@@ -473,7 +471,7 @@ namespace RFiDGear.Infrastructure.ReaderProviders
             }
             catch (Exception e)
             {
-                eventLog.WriteEntry(e.Message, EventLogEntryType.Error);
+                Log.ForContext<LibLogicalAccessProvider>().Error(e, "LibLogicalAccess operation failed.");
 
                 return ERROR.TransportError;
             }
@@ -501,7 +499,7 @@ namespace RFiDGear.Infrastructure.ReaderProviders
                         }
                         catch (Exception e)
                         {
-                            eventLog.WriteEntry(e.Message, EventLogEntryType.Error);
+                            Log.ForContext<LibLogicalAccessProvider>().Error(e, "LibLogicalAccess operation failed.");
                         }
                     }
 
@@ -546,7 +544,7 @@ namespace RFiDGear.Infrastructure.ReaderProviders
             }
             catch (Exception e)
             {
-                eventLog.WriteEntry(e.Message, EventLogEntryType.Error);
+                Log.ForContext<LibLogicalAccessProvider>().Error(e, "LibLogicalAccess operation failed.");
 
                 return ERROR.TransportError;
             }
@@ -623,7 +621,7 @@ namespace RFiDGear.Infrastructure.ReaderProviders
                     }
                     catch (Exception e)
                     {
-                        eventLog.WriteEntry(e.Message, EventLogEntryType.Error);
+                        Log.ForContext<LibLogicalAccessProvider>().Error(e, "LibLogicalAccess operation failed.");
                         return ERROR.AuthFailure;
                     }
                     return ERROR.NoError;
@@ -631,7 +629,7 @@ namespace RFiDGear.Infrastructure.ReaderProviders
             }
             catch (Exception e)
             {
-                eventLog.WriteEntry(e.Message, EventLogEntryType.Error);
+                Log.ForContext<LibLogicalAccessProvider>().Error(e, "LibLogicalAccess operation failed.");
                 return ERROR.AuthFailure;
             }
             return ERROR.NoError;
@@ -680,7 +678,7 @@ namespace RFiDGear.Infrastructure.ReaderProviders
                     }
                     catch (Exception e)
                     {
-                        eventLog.WriteEntry(e.Message, EventLogEntryType.Error);
+                        Log.ForContext<LibLogicalAccessProvider>().Error(e, "LibLogicalAccess operation failed.");
                         return ERROR.AuthFailure;
                     }
                     return ERROR.NoError;
@@ -688,7 +686,7 @@ namespace RFiDGear.Infrastructure.ReaderProviders
             }
             catch (Exception e)
             {
-                eventLog.WriteEntry(e.Message, EventLogEntryType.Error);
+                Log.ForContext<LibLogicalAccessProvider>().Error(e, "LibLogicalAccess operation failed.");
                 return ERROR.AuthFailure;
             }
             return ERROR.NoError;
@@ -726,7 +724,7 @@ namespace RFiDGear.Infrastructure.ReaderProviders
             }
             catch (Exception e)
             {
-                eventLog.WriteEntry(e.Message, EventLogEntryType.Error);
+                Log.ForContext<LibLogicalAccessProvider>().Error(e, "LibLogicalAccess operation failed.");
                 return ERROR.TransportError;
             }
         }

--- a/RFiDGear/Services/TaskExecution/TaskExecutionService.cs
+++ b/RFiDGear/Services/TaskExecution/TaskExecutionService.cs
@@ -1,7 +1,6 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -228,7 +227,6 @@ namespace RFiDGear.Services.TaskExecution
         public Action<bool> UpdateReaderBusy { get; set; }
         public Action NotifyTreeViewChanged { get; set; }
         public Action NotifyTasksChanged { get; set; }
-        public EventLog EventLog { get; set; }
         public TaskExecutionTimeouts Timeouts { get; set; } = TaskExecutionTimeouts.Default;
         public IReadOnlyList<TaskDescriptor> TaskDescriptors { get; set; }
         public IDictionary<ERROR, string> ErrorRouting { get; set; } = new Dictionary<ERROR, string>();
@@ -379,7 +377,6 @@ namespace RFiDGear.Services.TaskExecution
             catch (Exception e)
             {
                 logger.LogError("ExecuteOnceAsync", e, new { CurrentTaskIndex });
-                request.EventLog?.WriteEntry(e.ToString(), EventLogEntryType.Error);
                 throw;
             }
             finally

--- a/RFiDGear/ViewModels/MainWindowViewModel.cs
+++ b/RFiDGear/ViewModels/MainWindowViewModel.cs
@@ -19,6 +19,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Threading;
+using Serilog;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -50,7 +51,6 @@ namespace RFiDGear.ViewModel
     {
         private readonly Version Version = Assembly.GetExecutingAssembly().GetName().Version;
 #nullable enable
-        private readonly EventLog? eventLog;
 #nullable disable
         private readonly string[] args;
         private readonly Dictionary<string, string> variablesFromArgs = new Dictionary<string, string>();
@@ -138,7 +138,6 @@ namespace RFiDGear.ViewModel
             IsReaderBusy = false;
 
             var startupContext = appStartupInitializer.Initialize();
-            eventLog = startupContext.EventLog;
             mutex = startupContext.Mutex;
             args = startupContext.Arguments;
 
@@ -402,7 +401,7 @@ namespace RFiDGear.ViewModel
             }
             catch (Exception e)
             {
-                eventLog?.WriteEntry(e.Message, EventLogEntryType.Error);
+                Log.ForContext<MainWindowViewModel>().Error(e, "Failed to update chip.");
             }
 
             Mouse.OverrideCursor = null;
@@ -490,7 +489,7 @@ namespace RFiDGear.ViewModel
             }
             catch (Exception e)
             {
-                eventLog?.WriteEntry(e.Message, EventLogEntryType.Error);
+                Log.ForContext<MainWindowViewModel>().Error(e, "Failed to update chip.");
 
                 dialogs.Clear();
 
@@ -574,7 +573,7 @@ namespace RFiDGear.ViewModel
             }
             catch (Exception e)
             {
-                eventLog?.WriteEntry(e.Message, EventLogEntryType.Error);
+                Log.ForContext<MainWindowViewModel>().Error(e, "Failed to update chip.");
 
                 dialogs.Clear();
 
@@ -646,7 +645,7 @@ namespace RFiDGear.ViewModel
             }
             catch (Exception e)
             {
-                eventLog?.WriteEntry(e.Message, EventLogEntryType.Error);
+                Log.ForContext<MainWindowViewModel>().Error(e, "Failed to update chip.");
 
                 dialogs.Clear();
 
@@ -895,7 +894,7 @@ namespace RFiDGear.ViewModel
             }
             catch (Exception e)
             {
-                eventLog?.WriteEntry(e.Message, EventLogEntryType.Error);
+                Log.ForContext<MainWindowViewModel>().Error(e, "Failed to update chip.");
             }
 
             return Task.CompletedTask;
@@ -997,7 +996,6 @@ namespace RFiDGear.ViewModel
                 UpdateReaderBusy = status => IsReaderBusy = status,
                 NotifyTreeViewChanged = () => OnPropertyChanged(nameof(TreeViewParentNodes)),
                 NotifyTasksChanged = () => OnPropertyChanged(nameof(ChipTasks)),
-                EventLog = eventLog
             };
 
             try
@@ -1012,7 +1010,7 @@ namespace RFiDGear.ViewModel
             }
             catch (Exception ex)
             {
-                eventLog?.WriteEntry(ex.ToString(), EventLogEntryType.Error);
+                Log.ForContext<MainWindowViewModel>().Error(ex, "Task execution failed.");
                 Dialogs.Add(new CustomDialogViewModel
                 {
                     Caption = ResourceLoader.GetResource("messageBoxDefaultCaption"),

--- a/RFiDGear/ViewModels/TaskSetupViewModels/GenericChipTaskViewModel.cs
+++ b/RFiDGear/ViewModels/TaskSetupViewModels/GenericChipTaskViewModel.cs
@@ -14,16 +14,16 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
-using System.Reflection;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using System.Xml.Serialization;
 using Elatec.NET;
 using System.Linq;
+using System.Reflection;
 using LibLogicalAccess;
-using System.Diagnostics;
 using RFiDGear.Infrastructure;
 using RFiDGear.Infrastructure.Tasks;
+using Serilog;
 using RFiDGear.Infrastructure.ReaderProviders;
 using RFiDGear.Infrastructure.FileAccess;
 using RFiDGear.UI.MVVMDialogs.ViewModels.Interfaces;
@@ -36,7 +36,6 @@ namespace RFiDGear.ViewModel.TaskSetupViewModels
     public class GenericChipTaskViewModel : ObservableObject, IUserDialogViewModel, IGenericTask
     {
         #region fields
-        private readonly EventLog eventLog = new EventLog("Application", ".", Assembly.GetEntryAssembly().GetName().Name);
         private readonly object editedTaskReference; // Tracks the original task instance during edit mode.
 
         private protected ReportReaderWriter reportReaderWriter;
@@ -99,7 +98,7 @@ namespace RFiDGear.ViewModel.TaskSetupViewModels
             }
             catch (Exception e)
             {
-                eventLog.WriteEntry(e.Message, EventLogEntryType.Error);
+                Log.ForContext<GenericChipTaskViewModel>().Error(e, "Failed to create generic chip task model.");
             }
         }
 

--- a/RFiDGear/ViewModels/TaskSetupViewModels/MifareClassicSetupViewModel.cs
+++ b/RFiDGear/ViewModels/TaskSetupViewModels/MifareClassicSetupViewModel.cs
@@ -14,7 +14,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel.Composition;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -24,6 +23,7 @@ using System.Windows.Input;
 using System.Xml.Serialization;
 using RFiDGear.Infrastructure;
 using RFiDGear.Infrastructure.Tasks;
+using Serilog;
 using RFiDGear.Infrastructure.AccessControl;
 using RFiDGear.Infrastructure.ReaderProviders;
 using RFiDGear.Infrastructure.FileAccess;
@@ -40,7 +40,6 @@ namespace RFiDGear.ViewModel.TaskSetupViewModels
     public class MifareClassicSetupViewModel : ObservableObject, IUserDialogViewModel, IGenericTask
     {
         #region Fields
-        private readonly EventLog eventLog = new EventLog("Application", ".", Assembly.GetEntryAssembly().GetName().Name);
         private readonly object editedTaskReference; // Tracks the original task instance during edit mode.
 
         private readonly ObservableCollection<MifareClassicDataBlockAccessConditionModel> dataBlock_AccessBits = new ObservableCollection<MifareClassicDataBlockAccessConditionModel>
@@ -331,7 +330,7 @@ namespace RFiDGear.ViewModel.TaskSetupViewModels
             }
             catch (Exception e)
             {
-                eventLog.WriteEntry(e.Message, EventLogEntryType.Error);
+                Log.ForContext<MifareClassicSetupViewModel>().Error(e, "Mifare Classic setup operation failed.");
             }
         }
 
@@ -1999,7 +1998,7 @@ namespace RFiDGear.ViewModel.TaskSetupViewModels
                 }
                 catch (Exception e)
                 {
-                    eventLog.WriteEntry(e.Message, EventLogEntryType.Error);
+                    Log.ForContext<MifareClassicSetupViewModel>().Error(e, "Mifare Classic setup operation failed.");
                 }
             }
             return Task.CompletedTask;

--- a/RFiDGear/ViewModels/TaskSetupViewModels/MifareDesfireSetupViewModel.cs
+++ b/RFiDGear/ViewModels/TaskSetupViewModels/MifareDesfireSetupViewModel.cs
@@ -16,7 +16,6 @@ using System;
 using System.ComponentModel.Composition;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -27,6 +26,7 @@ using System.Windows.Input;
 using System.Xml.Serialization;
 using RFiDGear.Infrastructure;
 using RFiDGear.Infrastructure.Tasks;
+using Serilog;
 using RFiDGear.Infrastructure.AccessControl;
 using RFiDGear.Infrastructure.ReaderProviders;
 using RFiDGear.Infrastructure.FileAccess;
@@ -42,7 +42,6 @@ namespace RFiDGear.ViewModel.TaskSetupViewModels
     public class MifareDesfireSetupViewModel : ObservableObject, IUserDialogViewModel, IGenericTask
     {
         #region Fields
-        private readonly EventLog eventLog = new EventLog("Application", ".", Assembly.GetEntryAssembly().GetName().Name);
         private readonly object editedTaskReference; // Tracks the original task instance during edit mode.
         private bool hasFinalizedTask;
         private string desfireDataFilePath;
@@ -212,7 +211,7 @@ namespace RFiDGear.ViewModel.TaskSetupViewModels
             }
             catch (Exception e)
             {
-                eventLog.WriteEntry(e.Message, EventLogEntryType.Error);
+                Log.ForContext<MifareDesfireSetupViewModel>().Error(e, "Mifare DESFire setup operation failed.");
             }
         }
         #endregion
@@ -2553,7 +2552,7 @@ namespace RFiDGear.ViewModel.TaskSetupViewModels
                 }
                 catch (Exception e)
                 {
-                    eventLog.WriteEntry(e.Message, EventLogEntryType.Error);
+                    Log.ForContext<MifareDesfireSetupViewModel>().Error(e, "Mifare DESFire setup operation failed.");
                 }
             }
         }
@@ -2877,7 +2876,7 @@ namespace RFiDGear.ViewModel.TaskSetupViewModels
             }
             catch (Exception e)
             {
-                eventLog.WriteEntry(e.Message, EventLogEntryType.Error);
+                Log.ForContext<MifareDesfireSetupViewModel>().Error(e, "Mifare DESFire setup operation failed.");
                 StatusText += string.Format("{0}: Unable to save read data: {1}\n", DateTime.Now, e.Message);
             }
         }

--- a/RFiDGear/ViewModels/TaskSetupViewModels/MifareUltralightSetupViewModel.cs
+++ b/RFiDGear/ViewModels/TaskSetupViewModels/MifareUltralightSetupViewModel.cs
@@ -13,7 +13,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel.Composition;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -22,6 +21,7 @@ using System.Windows.Input;
 using System.Xml.Serialization;
 using RFiDGear.Infrastructure;
 using RFiDGear.Infrastructure.Tasks;
+using Serilog;
 using RFiDGear.Infrastructure.ReaderProviders;
 using RFiDGear.Infrastructure.FileAccess;
 using RFiDGear.UI.UIExtensions.Interfaces;
@@ -34,7 +34,6 @@ namespace RFiDGear.ViewModel.TaskSetupViewModels
     public class MifareUltralightSetupViewModel : ObservableObject, IUserDialogViewModel
     {
         #region Fields
-        private readonly EventLog eventLog = new EventLog("Application", ".", Assembly.GetEntryAssembly().GetName().Name);
         private readonly object editedTaskReference; // Tracks the original task instance during edit mode.
 
         private MifareUltralightChipModel chipModel;
@@ -128,7 +127,7 @@ namespace RFiDGear.ViewModel.TaskSetupViewModels
             }
             catch (Exception e)
             {
-                eventLog.WriteEntry(e.Message, EventLogEntryType.Error);
+                Log.ForContext<MifareUltralightSetupViewModel>().Error(e, "Mifare Ultralight setup operation failed.");
             }
 
         }


### PR DESCRIPTION
### Motivation
- Starting the app on machines where it was never installed could crash during startup because `EventLog.CreateEventSource(...)` requires elevated privileges.  
- The intent is to eliminate the Windows `EventLog` dependency and use the existing Serilog pipeline for application tracing and error reporting to avoid privileged operations during first-run.  
- Unit tests and startup flow required small adjustments because the startup context no longer carries an `EventLog` instance.  

### Description
- Removed Windows event-source creation and `EventLog` construction from `AppStartupInitializer` and simplified `AppStartupContext` to carry only the single-instance `Mutex` and CLI arguments.  
- Removed `EventLog` from `TaskExecutionRequest` and eliminated direct `EventLog.WriteEntry(...)` calls in the task execution path so errors are logged through the task logger/Serilog instead.  
- Replaced remaining `EventLog.WriteEntry(...)` usages across view models and reader providers (e.g. `MainWindowViewModel`, `ElatecNetProvider`, `LibLogicalAccessProvider`, and task setup view models) with Serilog calls such as `Log.ForContext<...>().Error(...)` or `Warning(...)`, and added `using Serilog;` where required.  
- Updated unit tests that constructed `AppStartupContext` to match the new constructor signature and adjusted tests to continue validating startup guards.  

### Testing
- Ran `dotnet build RFiDGear/RFiDGear.csproj -c Release`, which succeeded.  
- Attempted `dotnet build /workspace/RFiDGear/RFiDGear.sln -c Release`, which failed in this environment due to missing WiX toolset projects not required for the runtime change.  
- Ran `dotnet test RFiDGear.Tests/RFiDGear.Tests.csproj -c Release`, which built the tests successfully but the test host could not run in this Linux container because `Microsoft.WindowsDesktop.App` runtime is unavailable.  
- Verified no remaining Windows `EventLog` setup or write calls using a repository search (`rg`) for `EventLog`, `CreateEventSource`, `EventSourceCreationData`, and `WriteEntry(...)`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eca7eb5d48331aca841a07e5d1ed1)