### PR TITLE
Fix #193: handle missing DESFire AppNumberNew when editing tasks

### DIFF
--- a/RFiDGear.Tests/Issue193DesfireAppNumberNewTests.cs
+++ b/RFiDGear.Tests/Issue193DesfireAppNumberNewTests.cs
@@ -1,0 +1,51 @@
+using RFiDGear.Infrastructure.Tasks;
+using RFiDGear.UI.MVVMDialogs.ViewModels.Interfaces;
+using RFiDGear.ViewModel.TaskSetupViewModels;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RFiDGear.Tests
+{
+    public class Issue193DesfireAppNumberNewTests
+    {
+        [Fact]
+        public async Task AppNumberNew_AcceptsNullForMissingXmlElement()
+        {
+            await StaTestRunner.RunOnStaThreadAsync(() =>
+            {
+                var viewModel = new MifareDesfireSetupViewModel();
+
+                viewModel.AppNumberNew = null;
+
+                Assert.Null(viewModel.AppNumberNew);
+                Assert.Equal(false, viewModel.IsValidAppNumberNew);
+                Assert.Equal(0, viewModel.AppNumberNewAsInt);
+            });
+        }
+
+        [Fact]
+        public async Task EditConstructor_PreservesCurrentAppWhenAppNumberNewIsMissing()
+        {
+            await StaTestRunner.RunOnStaThreadAsync(() =>
+            {
+                var source = new MifareDesfireSetupViewModel
+                {
+                    SelectedTaskType = TaskType_MifareDesfireTask.ReadData,
+                    AppNumberCurrent = "0xF482D0"
+                };
+
+                Assert.Null(source.AppNumberNew);
+
+                var editor = new MifareDesfireSetupViewModel(
+                    source,
+                    new ObservableCollection<IDialogViewModel>());
+
+                Assert.Null(editor.AppNumberNew);
+                Assert.Equal(source.AppNumberCurrent, editor.AppNumberCurrent);
+                Assert.Equal(source.AppNumberCurrentAsInt, editor.AppNumberCurrentAsInt);
+                Assert.True(editor.IsValidAppNumberCurrent);
+            });
+        }
+    }
+}

--- a/RFiDGear/ViewModels/TaskSetupViewModels/MifareDesfireSetupViewModel.cs
+++ b/RFiDGear/ViewModels/TaskSetupViewModels/MifareDesfireSetupViewModel.cs
@@ -1325,14 +1325,7 @@ namespace RFiDGear.ViewModel.TaskSetupViewModels
             get => appNumberNew;
             set
             {
-                try
-                {
-                    appNumberNew = value.Length > 8 ? value.ToUpper().Remove(8) : value;
-                }
-                catch
-                {
-                    appNumberNew = value.ToUpper();
-                }
+                appNumberNew = value != null && value.Length > 8 ? value.ToUpper().Remove(8) : value;
                 IsValidAppNumberNew = TryParseDesfireAppId(value, out appNumberNewAsInt);
                 OnPropertyChanged(nameof(AppNumberNew));
             }


### PR DESCRIPTION
## Summary
- make the DESFire `AppNumberNew` setter null-safe so projects that omit the unused XML element can still be edited
- keep `AppNumberNew` absent rather than inventing a fallback value for file-operation tasks that use `AppNumberCurrent`
- add regression coverage for direct null assignment and the edit-constructor path

## Why
After #189, DESFire file operations such as `CreateFile`, `ReadData`, `WriteData`, and `ChangeFileSettings` use `AppNumberCurrent` for execution. A generated project may therefore legitimately omit `AppNumberNew`.

When such a task is opened in the editor, the copy constructor reflects over the source properties and assigns the missing value to `AppNumberNew`. The previous setter dereferenced `value` in the `try` block and then dereferenced it again in the `catch`, so `null` aborted setup initialization with a `NullReferenceException`.

The fix only removes that null dereference; existing non-null parsing/truncation behavior is unchanged.

## Testing
Executed the two new regression tests on GitHub Actions `windows-latest` with .NET 8:

```text
dotnet test RFiDGear.Tests/RFiDGear.Tests.csproj -c Release --filter "FullyQualifiedName~Issue193DesfireAppNumberNewTests"
```

Result: success.

The branch is based directly on current upstream `master` (`911b30d2e82882ae3268e676f4db7a9b4b050de5`) and contains one commit touching only the setter and the regression-test file.

Fixes #193