### PR TITLE
Fix #194: add correlated per-task execution outcome logs

### DIFF
--- a/RFiDGear.Tests/TaskExecutionServiceTests.cs
+++ b/RFiDGear.Tests/TaskExecutionServiceTests.cs
@@ -1,6 +1,8 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using RFiDGear.Infrastructure;
@@ -19,12 +21,13 @@ namespace RFiDGear.Tests
     /// </summary>
     public class TaskExecutionServiceTests
     {
-        private static TaskExecutionService BuildService()
+        private static TaskExecutionService BuildService(ITaskExecutionLogger logger = null)
         {
             return new TaskExecutionService(
                 new StubReaderDeviceProvider(),
                 new StubDispatcherTimerAdapter(),
-                new StubDispatcherTimerAdapter());
+                new StubDispatcherTimerAdapter(),
+                logger);
         }
 
         private static TaskExecutionRequest BuildRequest(IReadOnlyList<TaskDescriptor> descriptors)
@@ -164,6 +167,195 @@ namespace RFiDGear.Tests
         {
             var task = new StubTaskModel();
             Assert.Equal(TaskExecutionState.NotStarted, task.ExecutionState);
+        }
+
+
+        [Fact]
+        public async Task StructuredLogs_EmitCorrelatedPerTaskOutcomesAndSummary()
+        {
+            var logger = new CapturingTaskExecutionLogger();
+            var first = new LoggingStubTaskModel
+            {
+                CurrentTaskIndex = "10",
+                SelectedTaskType = "ReadData",
+                SelectedTaskDescription = "Read verification data"
+            };
+            var second = new LoggingStubTaskModel
+            {
+                CurrentTaskIndex = "11",
+                SelectedTaskType = "WriteData",
+                SelectedTaskDescription = "Write personalization data"
+            };
+
+            var descriptors = new List<TaskDescriptor>
+            {
+                new TaskDescriptor(0, first, ct =>
+                {
+                    first.CurrentTaskErrorLevel = ERROR.NoError;
+                    first.IsTaskCompletedSuccessfully = true;
+                    return Task.CompletedTask;
+                }),
+                new TaskDescriptor(1, second, ct =>
+                {
+                    second.CurrentTaskErrorLevel = ERROR.TransportError;
+                    second.IsTaskCompletedSuccessfully = false;
+                    return Task.CompletedTask;
+                })
+            };
+
+            await StaTestRunner.RunOnStaThreadAsync(async () =>
+            {
+                await BuildService(logger).ExecuteOnceAsync(BuildRequest(descriptors));
+            });
+
+            var outcomes = logger.Entries.Where(entry => entry.Stage == "Task.Outcome").ToList();
+            Assert.Equal(2, outcomes.Count);
+
+            var runIds = logger.Entries
+                .Where(entry => entry.Stage.StartsWith("TaskLoop", StringComparison.Ordinal) || entry.Stage == "Task.Outcome")
+                .Select(entry => GetStringProperty(entry.DetailsJson, "RunId"))
+                .Where(value => !string.IsNullOrWhiteSpace(value))
+                .Distinct()
+                .ToList();
+
+            Assert.Single(runIds);
+            Assert.Equal("10", GetStringProperty(outcomes[0].DetailsJson, "TaskId"));
+            Assert.Equal("ReadData", GetStringProperty(outcomes[0].DetailsJson, "TaskType"));
+            Assert.Equal("Executed", GetStringProperty(outcomes[0].DetailsJson, "Decision"));
+            Assert.Equal("Successful", GetStringProperty(outcomes[0].DetailsJson, "Outcome"));
+            Assert.Equal("11", GetStringProperty(outcomes[1].DetailsJson, "TaskId"));
+            Assert.Equal("Failed", GetStringProperty(outcomes[1].DetailsJson, "Outcome"));
+
+            var summary = Assert.Single(logger.Entries.Where(entry => entry.Stage == "TaskLoop.Summary"));
+            Assert.Equal(2, GetIntProperty(summary.DetailsJson, "Executed"));
+            Assert.Equal(0, GetIntProperty(summary.DetailsJson, "Skipped"));
+            Assert.Equal(1, GetIntProperty(summary.DetailsJson, "Failed"));
+            Assert.Equal(1, GetIntProperty(summary.DetailsJson, "Successful"));
+        }
+
+        [Fact]
+        public async Task StructuredLogs_RedactSecretsAndDoNotSerializeTaskKeyProperties()
+        {
+            const string secret = "00112233445566778899AABBCCDDEEFF";
+            var logger = new CapturingTaskExecutionLogger();
+            var task = new LoggingStubTaskModel
+            {
+                CurrentTaskIndex = "20",
+                SelectedTaskType = "WriteData",
+                SelectedTaskDescription = "Key=" + secret + " payload=" + secret,
+                DesfireAppKeyCurrent = secret
+            };
+
+            var descriptors = new List<TaskDescriptor>
+            {
+                new TaskDescriptor(0, task, ct =>
+                {
+                    task.CurrentTaskErrorLevel = ERROR.NoError;
+                    task.IsTaskCompletedSuccessfully = true;
+                    return Task.CompletedTask;
+                })
+            };
+
+            await StaTestRunner.RunOnStaThreadAsync(async () =>
+            {
+                await BuildService(logger).ExecuteOnceAsync(BuildRequest(descriptors));
+            });
+
+            var outcome = Assert.Single(logger.Entries.Where(entry => entry.Stage == "Task.Outcome"));
+            Assert.DoesNotContain(secret, outcome.DetailsJson);
+            Assert.DoesNotContain(nameof(LoggingStubTaskModel.DesfireAppKeyCurrent), outcome.DetailsJson);
+            Assert.Contains("REDACTED", outcome.DetailsJson);
+        }
+
+        [Fact]
+        public async Task StructuredLogs_RecordSanitizedTaskExceptionAndFailureSummary()
+        {
+            const string secret = "FFEEDDCCBBAA99887766554433221100";
+            var logger = new CapturingTaskExecutionLogger();
+            var task = new LoggingStubTaskModel
+            {
+                CurrentTaskIndex = "30",
+                SelectedTaskType = "AuthenticateApplication",
+                SelectedTaskDescription = "Authentication check"
+            };
+
+            var descriptors = new List<TaskDescriptor>
+            {
+                new TaskDescriptor(0, task, ct => throw new InvalidOperationException("Key=" + secret))
+            };
+
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await StaTestRunner.RunOnStaThreadAsync(async () =>
+                {
+                    await BuildService(logger).ExecuteOnceAsync(BuildRequest(descriptors));
+                });
+            });
+
+            var outcome = Assert.Single(logger.Entries.Where(entry => entry.Stage == "Task.Outcome"));
+            Assert.DoesNotContain(secret, outcome.DetailsJson);
+            Assert.Equal("InvalidOperationException", GetStringProperty(outcome.DetailsJson, "ExceptionType"));
+            Assert.Contains("REDACTED", GetStringProperty(outcome.DetailsJson, "ExceptionMessage"));
+
+            var summary = Assert.Single(logger.Entries.Where(entry => entry.Stage == "TaskLoop.Summary"));
+            Assert.Equal(1, GetIntProperty(summary.DetailsJson, "Executed"));
+            Assert.Equal(1, GetIntProperty(summary.DetailsJson, "Failed"));
+        }
+
+        private static string GetStringProperty(string json, string propertyName)
+        {
+            using var document = JsonDocument.Parse(json);
+            return document.RootElement.GetProperty(propertyName).ValueKind == JsonValueKind.Null
+                ? null
+                : document.RootElement.GetProperty(propertyName).GetString();
+        }
+
+        private static int GetIntProperty(string json, string propertyName)
+        {
+            using var document = JsonDocument.Parse(json);
+            return document.RootElement.GetProperty(propertyName).GetInt32();
+        }
+
+        private sealed class CapturingTaskExecutionLogger : ITaskExecutionLogger
+        {
+            public List<LogEntry> Entries { get; } = new List<LogEntry>();
+
+            public void LogInformation(string stage, object details = null)
+            {
+                Entries.Add(new LogEntry(stage, JsonSerializer.Serialize(details)));
+            }
+
+            public void LogError(string stage, Exception exception, object details = null)
+            {
+                Entries.Add(new LogEntry(stage, JsonSerializer.Serialize(details)));
+            }
+        }
+
+        private sealed class LogEntry
+        {
+            public LogEntry(string stage, string detailsJson)
+            {
+                Stage = stage;
+                DetailsJson = detailsJson;
+            }
+
+            public string Stage { get; }
+            public string DetailsJson { get; }
+        }
+
+        private sealed class LoggingStubTaskModel : IGenericTask
+        {
+            public bool? IsTaskCompletedSuccessfully { get; set; }
+            public ERROR SelectedExecuteConditionErrorLevel { get; set; }
+            public string SelectedExecuteConditionTaskIndex { get; set; } = string.Empty;
+            public ERROR CurrentTaskErrorLevel { get; set; }
+            public string CurrentTaskIndex { get; set; } = string.Empty;
+            public int SelectedTaskIndexAsInt => int.TryParse(CurrentTaskIndex, out var index) ? index : -1;
+            public ObservableCollection<TaskAttemptResult> AttemptResults { get; } = new ObservableCollection<TaskAttemptResult>();
+            public TaskExecutionState ExecutionState { get; set; } = TaskExecutionState.NotStarted;
+            public string SelectedTaskType { get; set; }
+            public string SelectedTaskDescription { get; set; }
+            public string DesfireAppKeyCurrent { get; set; }
         }
 
         private sealed class StubReaderDeviceProvider : IReaderDeviceProvider

--- a/RFiDGear.Tests/TaskExecutionServiceTests.cs
+++ b/RFiDGear.Tests/TaskExecutionServiceTests.cs
@@ -327,6 +327,7 @@ namespace RFiDGear.Tests
 
             public void LogError(string stage, Exception exception, object details = null)
             {
+                _ = exception;
                 Entries.Add(new LogEntry(stage, JsonSerializer.Serialize(details)));
             }
         }

--- a/RFiDGear/Services/TaskExecution/TaskExecutionService.cs
+++ b/RFiDGear/Services/TaskExecution/TaskExecutionService.cs
@@ -600,10 +600,7 @@ namespace RFiDGear.Services.TaskExecution
             }
 
             var loggedTaskPositions = new HashSet<int>();
-            var executedCount = 0;
-            var skippedCount = 0;
-            var failedCount = 0;
-            var successfulCount = 0;
+            var counters = new TaskRunCounters();
 
             try
             {
@@ -680,8 +677,8 @@ namespace RFiDGear.Services.TaskExecution
                     {
                         if (loggedTaskPositions.Add(taskPosition))
                         {
-                            executedCount++;
-                            failedCount++;
+                            counters.Executed++;
+                            counters.Failed++;
                             LogTaskOutcome(runId, descriptor, taskModel, "Executed", "Failed", null, ex);
                         }
 
@@ -695,15 +692,15 @@ namespace RFiDGear.Services.TaskExecution
 
                         if (loggedTaskPositions.Add(taskPosition))
                         {
-                            executedCount++;
+                            counters.Executed++;
                             var success = GetTaskSuccess(taskModel);
                             if (success == true)
                             {
-                                successfulCount++;
+                                counters.Successful++;
                             }
                             else if (success == false)
                             {
-                                failedCount++;
+                                counters.Failed++;
                             }
 
                             LogTaskOutcome(
@@ -716,7 +713,7 @@ namespace RFiDGear.Services.TaskExecution
                     }
                     else if (!executedTask && CurrentTaskIndex != taskPosition && loggedTaskPositions.Add(taskPosition))
                     {
-                        skippedCount++;
+                        counters.Skipped++;
                         LogTaskOutcome(
                             runId,
                             descriptor,
@@ -742,14 +739,25 @@ namespace RFiDGear.Services.TaskExecution
                 {
                     RunId = runId,
                     TotalTasks = descriptors?.Count ?? 0,
-                    Executed = executedCount,
-                    Skipped = skippedCount,
-                    Failed = failedCount,
-                    Successful = successfulCount,
-                    Unknown = Math.Max(0, executedCount - failedCount - successfulCount),
+                    Executed = counters.Executed,
+                    Skipped = counters.Skipped,
+                    Failed = counters.Failed,
+                    Successful = counters.Successful,
+                    Unknown = Math.Max(0, counters.Executed - counters.Failed - counters.Successful),
                     Timestamp = DateTimeOffset.UtcNow
                 });
             }
+        }
+
+        private sealed class TaskRunCounters
+        {
+            public int Executed { get; set; }
+
+            public int Skipped { get; set; }
+
+            public int Failed { get; set; }
+
+            public int Successful { get; set; }
         }
 
         private void LogTaskOutcome(

--- a/RFiDGear/Services/TaskExecution/TaskExecutionService.cs
+++ b/RFiDGear/Services/TaskExecution/TaskExecutionService.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Windows.Threading;
 
 using RFiDGear.Models;
@@ -175,6 +176,29 @@ namespace RFiDGear.Services.TaskExecution
     /// <summary>
     /// Serilog-backed logger used when no external task execution logger is provided.
     /// </summary>
+    internal static class TaskExecutionLogSanitizer
+    {
+        private static readonly Regex SensitiveAssignmentPattern = new Regex(
+            @"(?i)\b(?:key|masterkey|picckey|appkey|readkey|writekey|payload)\b\s*[:=]\s*[^\s,;]+",
+            RegexOptions.Compiled);
+
+        private static readonly Regex KeyLikeHexPattern = new Regex(
+            @"(?i)(?<![0-9a-f])(?:[0-9a-f]{48}|[0-9a-f]{32})(?![0-9a-f])",
+            RegexOptions.Compiled);
+
+        public static string Sanitize(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+
+            var sanitized = SensitiveAssignmentPattern.Replace(value, "[REDACTED]");
+            sanitized = KeyLikeHexPattern.Replace(sanitized, "[REDACTED_HEX]");
+            return sanitized.Length > 256 ? sanitized.Substring(0, 256) : sanitized;
+        }
+    }
+
     public class NullTaskExecutionLogger : ITaskExecutionLogger
     {
         private readonly ILogger logger = Log.ForContext<NullTaskExecutionLogger>();
@@ -186,7 +210,7 @@ namespace RFiDGear.Services.TaskExecution
 
         public void LogError(string stage, Exception exception, object details = null)
         {
-            logger.Error(exception, "{SerializedTaskLog}", Serialize(stage, "Error", details, exception));
+            logger.Error("{SerializedTaskLog}", Serialize(stage, "Error", details, exception));
         }
 
         private static string Serialize(string stage, string level, object details, Exception exception = null)
@@ -197,9 +221,9 @@ namespace RFiDGear.Services.TaskExecution
                 Level = level,
                 Exception = exception == null ? null : new
                 {
-                    exception.Message,
+                    Message = TaskExecutionLogSanitizer.Sanitize(exception.Message),
                     ExceptionType = exception.GetType().Name,
-                    exception.StackTrace
+                    StackTrace = TaskExecutionLogSanitizer.Sanitize(exception.StackTrace)
                 },
                 Details = details,
                 Timestamp = DateTimeOffset.UtcNow
@@ -327,6 +351,7 @@ namespace RFiDGear.Services.TaskExecution
             };
 
             var descriptors = BuildTaskDescriptors(request);
+            var runId = Guid.NewGuid().ToString("N");
 
 #if DEBUG
             taskTimeout.IsEnabled = false;
@@ -346,9 +371,10 @@ namespace RFiDGear.Services.TaskExecution
                 {
                     await ExecuteStageWithTimeout(
                         "TaskLoop",
-                        () => RunTaskLoopAsync(request, result, descriptors, null, null, cancellationToken),
+                        () => RunTaskLoopAsync(request, result, descriptors, null, null, runId, cancellationToken),
                         request.Timeouts?.TaskLoopTimeout,
-                        cancellationToken);
+                        cancellationToken,
+                        runId);
                 }
                 else
                 {
@@ -356,7 +382,8 @@ namespace RFiDGear.Services.TaskExecution
                         "DeviceDiscovery",
                         () => Task.FromResult(new DeviceDiscoveryResult(readerDeviceProvider.GetInstance())),
                         request.Timeouts?.DeviceDiscoveryTimeout,
-                        cancellationToken);
+                        cancellationToken,
+                        runId);
 
                     if (deviceResult.Device == null)
                     {
@@ -369,25 +396,28 @@ namespace RFiDGear.Services.TaskExecution
                             "ChipHydration",
                             () => HydrateChipAsync(device, cancellationToken),
                             request.Timeouts?.ChipHydrationTimeout,
-                            cancellationToken);
+                            cancellationToken,
+                        runId);
 
                         _ = await ExecuteStageWithTimeout(
                             "SelectionSync",
                             () => Task.FromResult(SynchronizeSelection(request, hydrationResult.Chip)),
                             request.Timeouts?.SelectionSyncTimeout,
-                            cancellationToken);
+                            cancellationToken,
+                        runId);
 
                         await ExecuteStageWithTimeout(
                             "TaskLoop",
-                            () => RunTaskLoopAsync(request, result, descriptors, hydrationResult.Chip, device, cancellationToken),
+                            () => RunTaskLoopAsync(request, result, descriptors, hydrationResult.Chip, device, runId, cancellationToken),
                             request.Timeouts?.TaskLoopTimeout,
-                            cancellationToken);
+                            cancellationToken,
+                        runId);
                     }
                 }
             }
             catch (Exception e)
             {
-                logger.LogError("ExecuteOnceAsync", e, new { CurrentTaskIndex });
+                logger.LogError("ExecuteOnceAsync", e, new { RunId = runId, CurrentTaskIndex });
                 throw;
             }
             finally
@@ -453,9 +483,9 @@ namespace RFiDGear.Services.TaskExecution
             return descriptors;
         }
 
-        private async Task<T> ExecuteStageWithTimeout<T>(string stageName, Func<Task<T>> stageAction, TimeSpan? timeout, CancellationToken cancellationToken)
+        private async Task<T> ExecuteStageWithTimeout<T>(string stageName, Func<Task<T>> stageAction, TimeSpan? timeout, CancellationToken cancellationToken, string runId)
         {
-            logger.LogInformation(stageName + ".Start", new { CurrentTaskIndex });
+            logger.LogInformation(stageName + ".Start", new { RunId = runId, CurrentTaskIndex });
 
             using var linkedCts = timeout.HasValue && timeout.Value != Timeout.InfiniteTimeSpan
                 ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)
@@ -481,30 +511,31 @@ namespace RFiDGear.Services.TaskExecution
                 }
 
                 var result = await stageTask;
-                logger.LogInformation(stageName + ".Success", new { Stage = stageName, CurrentTaskIndex, Timestamp = DateTimeOffset.UtcNow });
+                logger.LogInformation(stageName + ".Success", new { RunId = runId, Stage = stageName, CurrentTaskIndex, Timestamp = DateTimeOffset.UtcNow });
                 return result;
             }
             catch (Exception ex)
             {
                 logger.LogError(stageName + ".Failure", ex, new
                 {
+                    RunId = runId,
                     Stage = stageName,
                     CurrentTaskIndex,
                     ExceptionType = ex.GetType().Name,
-                    ex.Message,
+                    Message = TaskExecutionLogSanitizer.Sanitize(ex.Message),
                     Timestamp = DateTimeOffset.UtcNow
                 });
                 throw;
             }
         }
 
-        private Task ExecuteStageWithTimeout(string stageName, Func<Task> stageAction, TimeSpan? timeout, CancellationToken cancellationToken)
+        private Task ExecuteStageWithTimeout(string stageName, Func<Task> stageAction, TimeSpan? timeout, CancellationToken cancellationToken, string runId)
         {
             return ExecuteStageWithTimeout<object>(stageName, async () =>
             {
                 await stageAction();
                 return null;
-            }, timeout, cancellationToken);
+            }, timeout, cancellationToken, runId);
         }
 
         private async Task<ChipHydrationResult> HydrateChipAsync(ReaderDevice device, CancellationToken cancellationToken)
@@ -557,7 +588,7 @@ namespace RFiDGear.Services.TaskExecution
             return new SelectionSyncResult(hydratedChip, selectionChanged);
         }
 
-        private async Task RunTaskLoopAsync(TaskExecutionRequest request, TaskExecutionResult result, IReadOnlyList<TaskDescriptor> descriptors, GenericChipModel genericChip, ReaderDevice device, CancellationToken cancellationToken)
+        private async Task RunTaskLoopAsync(TaskExecutionRequest request, TaskExecutionResult result, IReadOnlyList<TaskDescriptor> descriptors, GenericChipModel genericChip, ReaderDevice device, string runId, CancellationToken cancellationToken)
         {
             if (request.TaskHandler?.TaskCollection != null)
             {
@@ -568,88 +599,300 @@ namespace RFiDGear.Services.TaskExecution
                 }
             }
 
-            while (descriptors != null && descriptors.Count > 0 && CurrentTaskIndex < descriptors.Count)
+            var loggedTaskPositions = new HashSet<int>();
+            var executedCount = 0;
+            var skippedCount = 0;
+            var failedCount = 0;
+            var successfulCount = 0;
+
+            try
             {
-                cancellationToken.ThrowIfCancellationRequested();
-                await Task.Delay(50, cancellationToken);
-
-                if (request.RunSelectedOnly && request.TaskHandler.TaskCollection != null)
+                while (descriptors != null && descriptors.Count > 0 && CurrentTaskIndex < descriptors.Count)
                 {
-                    CurrentTaskIndex = request.TaskHandler.TaskCollection.IndexOf(request.SelectedSetupViewModel);
-                }
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await Task.Delay(50, cancellationToken);
 
-                taskTimeout.Stop();
-                taskTimeout.Start();
-                taskTimeout.IsEnabled = true;
-                taskTimeout.Tag = CurrentTaskIndex;
-
-                var descriptor = descriptors[CurrentTaskIndex];
-                var taskModel = descriptor.Task ?? request.TaskHandler?.TaskCollection?[CurrentTaskIndex] as IGenericTask;
-
-                request.ConfigureTaskStrategy?.Invoke(
-                    taskModel,
-                    request.AlternateExecutionKeys ?? request.VariablesFromArgs ?? new Dictionary<string, string>());
-
-                var executedTask = false;
-                if (request.TaskHandler?.TaskCollection != null && request.TaskHandler.TaskCollection.Count > CurrentTaskIndex)
-                {
-                    request.SelectedSetupViewModel = request.TaskHandler.TaskCollection[CurrentTaskIndex];
-                }
-                else if (descriptor.Task != null)
-                {
-                    request.SelectedSetupViewModel = descriptor.Task;
-                }
-
-                request.UpdateSelectedSetupViewModel?.Invoke(request.SelectedSetupViewModel);
-
-                if (descriptor.ExecuteAsync != null)
-                {
-                    await descriptor.ExecuteAsync(cancellationToken);
-                    executedTask = true;
-                    if (!request.RunSelectedOnly)
+                    if (request.RunSelectedOnly && request.TaskHandler.TaskCollection != null)
                     {
-                        CurrentTaskIndex++;
+                        CurrentTaskIndex = request.TaskHandler.TaskCollection.IndexOf(request.SelectedSetupViewModel);
                     }
-                }
-                else if (request.TaskHandler?.TaskCollection != null && request.TaskHandler.TaskCollection.Count > CurrentTaskIndex)
-                {
-                    switch (request.TaskHandler.TaskCollection[CurrentTaskIndex])
+
+                    taskTimeout.Stop();
+                    taskTimeout.Start();
+                    taskTimeout.IsEnabled = true;
+                    taskTimeout.Tag = CurrentTaskIndex;
+
+                    var taskPosition = CurrentTaskIndex;
+                    var descriptor = descriptors[taskPosition];
+                    var taskModel = descriptor.Task ?? request.TaskHandler?.TaskCollection?[taskPosition] as IGenericTask;
+
+                    request.ConfigureTaskStrategy?.Invoke(
+                        taskModel,
+                        request.AlternateExecutionKeys ?? request.VariablesFromArgs ?? new Dictionary<string, string>());
+
+                    var executedTask = false;
+                    if (request.TaskHandler?.TaskCollection != null && request.TaskHandler.TaskCollection.Count > taskPosition)
                     {
-                        case CommonTaskViewModel commonTask:
-                            executedTask = await HandleCommonTaskAsync(commonTask, request, result, descriptors, genericChip, device);
-                            break;
-                        case GenericChipTaskViewModel genericTask:
-                            executedTask = await HandleGenericChipTaskAsync(genericTask, request, descriptors, device);
-                            break;
-                        case MifareClassicSetupViewModel classicTask:
-                            executedTask = await HandleClassicTaskAsync(classicTask, request, descriptors);
-                            break;
-                        case MifareDesfireSetupViewModel desfireTask:
-                            executedTask = await HandleDesfireTaskAsync(desfireTask, request, descriptors);
-                            break;
-                        case MifareUltralightSetupViewModel _:
-                            break;
-                        default:
-                            break;
+                        request.SelectedSetupViewModel = request.TaskHandler.TaskCollection[taskPosition];
                     }
-                }
+                    else if (descriptor.Task != null)
+                    {
+                        request.SelectedSetupViewModel = descriptor.Task;
+                    }
 
-                if (executedTask && taskModel != null)
-                {
-                    RecordTaskAttempt(taskModel);
-                    ApplyErrorRouting(taskModel, request, descriptors);
-                }
+                    request.UpdateSelectedSetupViewModel?.Invoke(request.SelectedSetupViewModel);
 
-                if (request.RunSelectedOnly)
-                {
-                    break;
-                }
+                    try
+                    {
+                        if (descriptor.ExecuteAsync != null)
+                        {
+                            await descriptor.ExecuteAsync(cancellationToken);
+                            executedTask = true;
+                            if (!request.RunSelectedOnly)
+                            {
+                                CurrentTaskIndex++;
+                            }
+                        }
+                        else if (request.TaskHandler?.TaskCollection != null && request.TaskHandler.TaskCollection.Count > taskPosition)
+                        {
+                            switch (request.TaskHandler.TaskCollection[taskPosition])
+                            {
+                                case CommonTaskViewModel commonTask:
+                                    executedTask = await HandleCommonTaskAsync(commonTask, request, result, descriptors, genericChip, device);
+                                    break;
+                                case GenericChipTaskViewModel genericTask:
+                                    executedTask = await HandleGenericChipTaskAsync(genericTask, request, descriptors, device);
+                                    break;
+                                case MifareClassicSetupViewModel classicTask:
+                                    executedTask = await HandleClassicTaskAsync(classicTask, request, descriptors);
+                                    break;
+                                case MifareDesfireSetupViewModel desfireTask:
+                                    executedTask = await HandleDesfireTaskAsync(desfireTask, request, descriptors);
+                                    break;
+                                case MifareUltralightSetupViewModel _:
+                                    break;
+                                default:
+                                    break;
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        if (loggedTaskPositions.Add(taskPosition))
+                        {
+                            executedCount++;
+                            failedCount++;
+                            LogTaskOutcome(runId, descriptor, taskModel, "Executed", "Failed", null, ex);
+                        }
 
+                        throw;
+                    }
+
+                    if (executedTask && taskModel != null)
+                    {
+                        RecordTaskAttempt(taskModel);
+                        ApplyErrorRouting(taskModel, request, descriptors);
+
+                        if (loggedTaskPositions.Add(taskPosition))
+                        {
+                            executedCount++;
+                            var success = GetTaskSuccess(taskModel);
+                            if (success == true)
+                            {
+                                successfulCount++;
+                            }
+                            else if (success == false)
+                            {
+                                failedCount++;
+                            }
+
+                            LogTaskOutcome(
+                                runId,
+                                descriptor,
+                                taskModel,
+                                "Executed",
+                                success == true ? "Successful" : success == false ? "Failed" : "Unknown");
+                        }
+                    }
+                    else if (!executedTask && CurrentTaskIndex != taskPosition && loggedTaskPositions.Add(taskPosition))
+                    {
+                        skippedCount++;
+                        LogTaskOutcome(
+                            runId,
+                            descriptor,
+                            taskModel,
+                            "Skipped",
+                            "Skipped",
+                            GetSkipReason(taskModel));
+                    }
+
+                    if (request.RunSelectedOnly)
+                    {
+                        break;
+                    }
+
+                    request.NotifyTreeViewChanged?.Invoke();
+                }
+            }
+            finally
+            {
                 request.NotifyTreeViewChanged?.Invoke();
+                taskTimeout.Stop();
+                logger.LogInformation("TaskLoop.Summary", new
+                {
+                    RunId = runId,
+                    TotalTasks = descriptors?.Count ?? 0,
+                    Executed = executedCount,
+                    Skipped = skippedCount,
+                    Failed = failedCount,
+                    Successful = successfulCount,
+                    Unknown = Math.Max(0, executedCount - failedCount - successfulCount),
+                    Timestamp = DateTimeOffset.UtcNow
+                });
+            }
+        }
+
+        private void LogTaskOutcome(
+            string runId,
+            TaskDescriptor descriptor,
+            IGenericTask taskModel,
+            string decision,
+            string outcome,
+            string skipReason = null,
+            Exception exception = null)
+        {
+            logger.LogInformation("Task.Outcome", new
+            {
+                RunId = runId,
+                TaskPosition = descriptor?.Index ?? CurrentTaskIndex,
+                TaskId = TaskExecutionLogSanitizer.Sanitize(descriptor?.Id ?? taskModel?.CurrentTaskIndex),
+                TaskType = GetTaskTypeName(taskModel),
+                Description = GetTaskDescription(taskModel),
+                Decision = decision,
+                SkipReason = skipReason,
+                Outcome = outcome,
+                ErrorCode = taskModel?.CurrentTaskErrorLevel.ToString(),
+                IsSuccessful = GetTaskSuccess(taskModel),
+                ExceptionType = exception?.GetType().Name,
+                ExceptionMessage = TaskExecutionLogSanitizer.Sanitize(exception?.Message),
+                IO = GetSafeIoMetadata(taskModel),
+                Timestamp = DateTimeOffset.UtcNow
+            });
+        }
+
+        private static bool? GetTaskSuccess(IGenericTask taskModel)
+        {
+            if (taskModel == null)
+            {
+                return null;
             }
 
-            request.NotifyTreeViewChanged?.Invoke();
-            taskTimeout.Stop();
+            if (taskModel.IsTaskCompletedSuccessfully.HasValue)
+            {
+                return taskModel.IsTaskCompletedSuccessfully.Value;
+            }
+
+            if (taskModel.CurrentTaskErrorLevel == ERROR.NoError)
+            {
+                return true;
+            }
+
+            return taskModel.CurrentTaskErrorLevel == ERROR.Empty ? null : false;
+        }
+
+        private static string GetSkipReason(IGenericTask taskModel)
+        {
+            if (taskModel == null)
+            {
+                return "TaskModelUnavailable";
+            }
+
+            return taskModel.SelectedExecuteConditionErrorLevel != ERROR.Empty
+                ? "ExecuteConditionNotMet"
+                : "NotExecuted";
+        }
+
+        private static string GetTaskTypeName(IGenericTask taskModel)
+        {
+            if (taskModel == null)
+            {
+                return "Unknown";
+            }
+
+            try
+            {
+                var value = taskModel.GetType().GetProperty("SelectedTaskType")?.GetValue(taskModel);
+                return TaskExecutionLogSanitizer.Sanitize(value?.ToString() ?? taskModel.GetType().Name);
+            }
+            catch
+            {
+                return taskModel.GetType().Name;
+            }
+        }
+
+        private static string GetTaskDescription(IGenericTask taskModel)
+        {
+            if (taskModel == null)
+            {
+                return null;
+            }
+
+            try
+            {
+                var value = taskModel.GetType().GetProperty("SelectedTaskDescription")?.GetValue(taskModel) as string;
+                return TaskExecutionLogSanitizer.Sanitize(value);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static object GetSafeIoMetadata(IGenericTask taskModel)
+        {
+            if (taskModel == null)
+            {
+                return null;
+            }
+
+            var metadata = new Dictionary<string, object>();
+            AddSafeIntegerMetadata(metadata, taskModel, "FileNumberCurrentAsInt", "FileNumber");
+            AddSafeIntegerMetadata(metadata, taskModel, "FileSizeCurrentAsInt", "FileSizeBytes");
+
+            try
+            {
+                var outputPath = taskModel.GetType().GetProperty("DesfireReadDataFilePath")?.GetValue(taskModel) as string;
+                if (outputPath != null)
+                {
+                    metadata["OutputConfigured"] = !string.IsNullOrWhiteSpace(outputPath);
+                }
+            }
+            catch
+            {
+                // Diagnostic metadata must never affect task execution.
+            }
+
+            return metadata.Count == 0 ? null : metadata;
+        }
+
+        private static void AddSafeIntegerMetadata(
+            IDictionary<string, object> metadata,
+            object source,
+            string propertyName,
+            string outputName)
+        {
+            try
+            {
+                var value = source.GetType().GetProperty(propertyName)?.GetValue(source);
+                if (value is int integerValue)
+                {
+                    metadata[outputName] = integerValue;
+                }
+            }
+            catch
+            {
+                // Diagnostic metadata must never affect task execution.
+            }
         }
 
         private void ResetSelectionState(TaskExecutionRequest request, TaskExecutionResult result)


### PR DESCRIPTION
## Summary
- add a shared `RunId` to structured execution-stage, per-task, and task-loop summary logs
- emit exactly one `Task.Outcome` record per task, including executed/skipped decision, result/error code, sanitized task type/description, and safe I/O metadata
- emit `TaskLoop.Summary` with executed/skipped/failed/successful/unknown counts
- redact key/payload assignments and 16-/24-byte key-looking hex values from task descriptions and exception text
- avoid passing the raw exception object to the default Serilog logger so sanitized exception text cannot be bypassed

## Execution semantics
Concrete ViewModel tasks can occupy two task-loop iterations: the first performs the task and marks it completed, while the next advances the index. The implementation tracks task positions already reported so this does **not** produce duplicate task outcomes.

Condition-based tasks that advance without execution are reported once as `Skipped` with `ExecuteConditionNotMet` where applicable.

## Logged task metadata
The per-task record intentionally uses a whitelist rather than serializing the task object. It contains:
- run correlation ID
- sequential task position / task ID
- task type and sanitized description
- executed/skipped decision and skip reason
- outcome, error code, success state
- sanitized exception type/message when a task throws
- safe I/O metadata only (`FileNumber`, `FileSizeBytes`, and whether an output path is configured)
- timestamp

Keys, payload contents, key properties, and actual output paths are not serialized.

## Testing
The `TaskExecutionServiceTests` suite was run on GitHub Actions `windows-latest` with .NET 8 after the implementation and again after the final exception-logging hardening:

```text
dotnet test RFiDGear.Tests/RFiDGear.Tests.csproj -c Release --filter "FullyQualifiedName~TaskExecutionServiceTests"
```

Both runs completed successfully. New regression coverage verifies:
- one correlated outcome per task plus final summary
- success/failure counters and error codes
- redaction of key/payload-like values and absence of task key properties
- sanitized task-exception outcome and failure summary

The final branch is based directly on current upstream `master` (`911b30d2e82882ae3268e676f4db7a9b4b050de5`) and contains one commit touching only `TaskExecutionService.cs` and its tests.

Fixes #194