### PR TITLE
Fix #195: stabilize sequenced DESFire operations on TWN4 LEGIC

### DIFF
--- a/RFiDGear.Tests/ElatecNetProviderTests.cs
+++ b/RFiDGear.Tests/ElatecNetProviderTests.cs
@@ -124,7 +124,7 @@ namespace RFiDGear.Tests
                 _fileNo: 0,
                 _fileSize: 16);
 
-            Assert.NotEqual(ERROR.NoError, result);
+            Assert.Equal(ERROR.PermissionDenied, result);
         }
 
         [Fact]
@@ -144,6 +144,103 @@ namespace RFiDGear.Tests
                 _fileSize: 16);
 
             Assert.Equal(ERROR.ProtocolConstraint, result);
+        }
+
+        [Fact]
+        public async Task ReadMiFareDESFireChipFile_UsesSingleProviderOwnedAuthBoundary()
+        {
+            var provider = new DataOperationTestProvider();
+
+            var result = await provider.ReadMiFareDESFireChipFile(
+                "00000000000000000000000000000000",
+                DESFireKeyType.DF_KEY_AES,
+                1,
+                RfidEncryptionMode.CM_ENCRYPT,
+                2,
+                0x123456,
+                8);
+
+            Assert.Equal(ERROR.NoError, result);
+            Assert.Equal(1, provider.AuthCalls);
+            Assert.Equal(1, provider.ReadCalls);
+            Assert.Equal(0, provider.WriteCalls);
+        }
+
+        [Fact]
+        public async Task WriteMiFareDESFireChipFile_UsesSingleProviderOwnedAuthBoundary()
+        {
+            var provider = new DataOperationTestProvider();
+
+            var result = await provider.WriteMiFareDESFireChipFile(
+                "00000000000000000000000000000000",
+                DESFireKeyType.DF_KEY_AES,
+                2,
+                RfidEncryptionMode.CM_ENCRYPT,
+                3,
+                0x123456,
+                new byte[] { 1, 2, 3, 4 });
+
+            Assert.Equal(ERROR.NoError, result);
+            Assert.Equal(1, provider.AuthCalls);
+            Assert.Equal(0, provider.ReadCalls);
+            Assert.Equal(1, provider.WriteCalls);
+        }
+
+        [Fact]
+        public async Task ReadMiFareDESFireChipFile_AuthFailure_DoesNotAttemptRead()
+        {
+            var provider = new DataOperationTestProvider(ERROR.AuthFailure);
+
+            var result = await provider.ReadMiFareDESFireChipFile(
+                "00000000000000000000000000000000",
+                DESFireKeyType.DF_KEY_AES,
+                1,
+                RfidEncryptionMode.CM_ENCRYPT,
+                0,
+                1,
+                4);
+
+            Assert.Equal(ERROR.AuthFailure, result);
+            Assert.Equal(1, provider.AuthCalls);
+            Assert.Equal(0, provider.ReadCalls);
+        }
+
+        [Fact]
+        public async Task ReadMiFareDESFireChipFile_SdkOperationFailure_ReturnsPermissionDenied()
+        {
+            var provider = new DataOperationTestProvider(throwOnRead: true);
+
+            var result = await provider.ReadMiFareDESFireChipFile(
+                "00000000000000000000000000000000",
+                DESFireKeyType.DF_KEY_AES,
+                1,
+                RfidEncryptionMode.CM_ENCRYPT,
+                0,
+                1,
+                4);
+
+            Assert.Equal(ERROR.PermissionDenied, result);
+            Assert.Equal(1, provider.AuthCalls);
+            Assert.Equal(1, provider.ReadCalls);
+        }
+
+        [Fact]
+        public async Task WriteMiFareDESFireChipFile_SdkOperationFailure_ReturnsPermissionDenied()
+        {
+            var provider = new DataOperationTestProvider(throwOnWrite: true);
+
+            var result = await provider.WriteMiFareDESFireChipFile(
+                "00000000000000000000000000000000",
+                DESFireKeyType.DF_KEY_AES,
+                1,
+                RfidEncryptionMode.CM_ENCRYPT,
+                0,
+                1,
+                new byte[] { 1, 2, 3, 4 });
+
+            Assert.Equal(ERROR.PermissionDenied, result);
+            Assert.Equal(1, provider.AuthCalls);
+            Assert.Equal(1, provider.WriteCalls);
         }
 
         private sealed class CreateFileTestProvider : ElatecNetProvider
@@ -178,6 +275,46 @@ namespace RFiDGear.Tests
                 if (_throwOnCreate)
                     throw new InvalidOperationException("simulated create failure");
                 BackupFileRequested = true;
+                return Task.CompletedTask;
+            }
+        }
+
+        private sealed class DataOperationTestProvider : ElatecNetProvider
+        {
+            private readonly ERROR _authResult;
+            private readonly bool _throwOnRead;
+            private readonly bool _throwOnWrite;
+
+            public int AuthCalls { get; private set; }
+            public int ReadCalls { get; private set; }
+            public int WriteCalls { get; private set; }
+
+            public DataOperationTestProvider(ERROR authResult = ERROR.NoError, bool throwOnRead = false, bool throwOnWrite = false)
+            {
+                _authResult = authResult;
+                _throwOnRead = throwOnRead;
+                _throwOnWrite = throwOnWrite;
+            }
+
+            protected override Task<ERROR> AuthToMifareDesfireApplicationCore(string key, DESFireKeyType keyType, int keyNumber, int appId)
+            {
+                AuthCalls++;
+                return Task.FromResult(_authResult);
+            }
+
+            protected override Task<byte[]> ReadDesfireDataAsync(byte fileNo, int fileSize, RfidEncryptionMode encMode)
+            {
+                ReadCalls++;
+                if (_throwOnRead)
+                    throw new InvalidOperationException("Simulated SDK read failure");
+                return Task.FromResult(new byte[fileSize]);
+            }
+
+            protected override Task WriteDesfireDataAsync(byte fileNo, byte[] data, RfidEncryptionMode encMode)
+            {
+                WriteCalls++;
+                if (_throwOnWrite)
+                    throw new InvalidOperationException("Simulated SDK write failure");
                 return Task.CompletedTask;
             }
         }

--- a/RFiDGear.Tests/ElatecNetProviderTests.cs
+++ b/RFiDGear.Tests/ElatecNetProviderTests.cs
@@ -305,6 +305,7 @@ namespace RFiDGear.Tests
             protected override Task<byte[]> ReadDesfireDataAsync(byte fileNo, int fileSize, RfidEncryptionMode encMode)
             {
                 _ = fileNo;
+                _ = encMode;
                 ReadCalls++;
                 if (_throwOnRead)
                 {
@@ -316,6 +317,8 @@ namespace RFiDGear.Tests
             protected override Task WriteDesfireDataAsync(byte fileNo, byte[] data, RfidEncryptionMode encMode)
             {
                 _ = fileNo;
+                _ = data;
+                _ = encMode;
                 WriteCalls++;
                 if (_throwOnWrite)
                 {

--- a/RFiDGear.Tests/ElatecNetProviderTests.cs
+++ b/RFiDGear.Tests/ElatecNetProviderTests.cs
@@ -304,17 +304,23 @@ namespace RFiDGear.Tests
 
             protected override Task<byte[]> ReadDesfireDataAsync(byte fileNo, int fileSize, RfidEncryptionMode encMode)
             {
+                _ = fileNo;
                 ReadCalls++;
                 if (_throwOnRead)
+                {
                     throw new InvalidOperationException("Simulated SDK read failure");
+                }
                 return Task.FromResult(new byte[fileSize]);
             }
 
             protected override Task WriteDesfireDataAsync(byte fileNo, byte[] data, RfidEncryptionMode encMode)
             {
+                _ = fileNo;
                 WriteCalls++;
                 if (_throwOnWrite)
+                {
                     throw new InvalidOperationException("Simulated SDK write failure");
+                }
                 return Task.CompletedTask;
             }
         }

--- a/RFiDGear.Tests/MifareDesfireSetupViewModelTests.cs
+++ b/RFiDGear.Tests/MifareDesfireSetupViewModelTests.cs
@@ -818,6 +818,10 @@ namespace RFiDGear.Tests
                 int _appID, int _fileNo, int _fileSize, int _minValue = 0, int _maxValue = 1000,
                 int _initValue = 0, bool _isValueLimited = false, int _maxNbOfRecords = 100)
             {
+                _ = _keyTypeAppMasterKey;
+                _ = _fileType;
+                _ = _appID;
+                _ = _initValue;
                 LastCreateFileKey = _appMasterKey;
                 CreateFileCalls++;
                 return Task.FromResult(ERROR.NoError);
@@ -828,6 +832,8 @@ namespace RFiDGear.Tests
                 DESFireKeyType _keyTypeTargetApplication, int _maxNbKeys, int _appID,
                 bool authenticateToPICCFirst = true)
             {
+                _ = _keySettingsTarget;
+                _ = _keyTypeTargetApplication;
                 LastCreateApplicationKey = _piccMasterKey;
                 CreateApplicationCalls++;
                 return Task.FromResult(OperationResult.Success(

--- a/RFiDGear.Tests/MifareDesfireSetupViewModelTests.cs
+++ b/RFiDGear.Tests/MifareDesfireSetupViewModelTests.cs
@@ -820,8 +820,16 @@ namespace RFiDGear.Tests
             {
                 _ = _keyTypeAppMasterKey;
                 _ = _fileType;
+                _ = _accessRights;
+                _ = _encMode;
                 _ = _appID;
+                _ = _fileNo;
+                _ = _fileSize;
+                _ = _minValue;
+                _ = _maxValue;
                 _ = _initValue;
+                _ = _isValueLimited;
+                _ = _maxNbOfRecords;
                 LastCreateFileKey = _appMasterKey;
                 CreateFileCalls++;
                 return Task.FromResult(ERROR.NoError);
@@ -833,7 +841,10 @@ namespace RFiDGear.Tests
                 bool authenticateToPICCFirst = true)
             {
                 _ = _keySettingsTarget;
+                _ = _keyTypePiccMasterKey;
                 _ = _keyTypeTargetApplication;
+                _ = _maxNbKeys;
+                _ = _appID;
                 LastCreateApplicationKey = _piccMasterKey;
                 CreateApplicationCalls++;
                 return Task.FromResult(OperationResult.Success(

--- a/RFiDGear.Tests/MifareDesfireSetupViewModelTests.cs
+++ b/RFiDGear.Tests/MifareDesfireSetupViewModelTests.cs
@@ -565,7 +565,7 @@ namespace RFiDGear.Tests
         }
 
         [Fact]
-        public async Task ReadDataCommand_UsesReadKeyForAuthenticationAndRead()
+        public async Task ReadDataCommand_UsesProviderOwnedAuthenticationAndReadKey()
         {
             await RunOnStaThreadAsync(async () =>
             {
@@ -597,9 +597,7 @@ namespace RFiDGear.Tests
 
                     await viewModel.ReadDataCommand.ExecuteAsync(null);
 
-                    Assert.Equal(viewModel.DesfireReadKeyCurrent, fakeProvider.LastAuthKey);
-                    Assert.Equal(viewModel.SelectedDesfireReadKeyEncryptionType, fakeProvider.LastAuthKeyType);
-                    Assert.Equal(1, fakeProvider.LastAuthKeyNumber);
+                    Assert.Null(fakeProvider.LastAuthKey);
                     Assert.Equal(viewModel.DesfireReadKeyCurrent, fakeProvider.LastReadKey);
                     Assert.Equal(viewModel.SelectedDesfireReadKeyEncryptionType, fakeProvider.LastReadKeyType);
                     Assert.Equal(1, fakeProvider.LastReadKeyNumber);
@@ -614,7 +612,7 @@ namespace RFiDGear.Tests
         }
 
         [Fact]
-        public async Task WriteDataCommand_UsesWriteKeyForAuthenticationAndWrite()
+        public async Task WriteDataCommand_UsesProviderOwnedAuthenticationAndWriteKey()
         {
             await RunOnStaThreadAsync(async () =>
             {
@@ -646,9 +644,7 @@ namespace RFiDGear.Tests
 
                     await viewModel.WriteDataCommand.ExecuteAsync(null);
 
-                    Assert.Equal(viewModel.DesfireWriteKeyCurrent, fakeProvider.LastAuthKey);
-                    Assert.Equal(viewModel.SelectedDesfireWriteKeyEncryptionType, fakeProvider.LastAuthKeyType);
-                    Assert.Equal(3, fakeProvider.LastAuthKeyNumber);
+                    Assert.Null(fakeProvider.LastAuthKey);
                     Assert.Null(fakeProvider.LastReadKey);
                     Assert.Equal(viewModel.DesfireWriteKeyCurrent, fakeProvider.LastWriteKey);
                     Assert.Equal(viewModel.SelectedDesfireWriteKeyEncryptionType, fakeProvider.LastWriteKeyType);

--- a/RFiDGear.Tests/MifareDesfireSetupViewModelTests.cs
+++ b/RFiDGear.Tests/MifareDesfireSetupViewModelTests.cs
@@ -658,6 +658,77 @@ namespace RFiDGear.Tests
             });
         }
 
+        [Fact]
+        public async Task CreateFileCommand_UsesProviderOwnedAuthentication()
+        {
+            await RunOnStaThreadAsync(async () =>
+            {
+                var fakeProvider = new FakeElatecNetProvider();
+                var viewModel = new MifareDesfireSetupViewModel
+                {
+                    AppNumberCurrent = "1",
+                    AppNumberNew = "1",
+                    FileNumberCurrent = "0",
+                    FileSizeCurrent = "16",
+                    DesfireAppKeyCurrent = "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00",
+                    SelectedDesfireAppKeyEncryptionTypeCurrent = DESFireKeyType.DF_KEY_AES
+                };
+
+                var originalReader = ReaderDevice.Reader;
+                var originalInstance = GetReaderDeviceInstance();
+                try
+                {
+                    ReaderDevice.Reader = ReaderTypes.Elatec;
+                    SetReaderDeviceInstance(fakeProvider);
+
+                    await viewModel.CreateFileCommand.ExecuteAsync(null);
+
+                    Assert.Null(fakeProvider.LastAuthKey);
+                    Assert.Equal(viewModel.DesfireAppKeyCurrent, fakeProvider.LastCreateFileKey);
+                    Assert.Equal(1, fakeProvider.CreateFileCalls);
+                }
+                finally
+                {
+                    ReaderDevice.Reader = originalReader;
+                    SetReaderDeviceInstance(originalInstance);
+                }
+            });
+        }
+
+        [Fact]
+        public async Task CreateApplicationCommand_UsesProviderOwnedAuthentication()
+        {
+            await RunOnStaThreadAsync(async () =>
+            {
+                var fakeProvider = new FakeElatecNetProvider();
+                var viewModel = new MifareDesfireSetupViewModel
+                {
+                    AppNumberNew = "1",
+                    SelectedDesfireMasterKeyEncryptionTypeCurrent = DESFireKeyType.DF_KEY_AES,
+                    DesfireMasterKeyCurrent = "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00"
+                };
+
+                var originalReader = ReaderDevice.Reader;
+                var originalInstance = GetReaderDeviceInstance();
+                try
+                {
+                    ReaderDevice.Reader = ReaderTypes.Elatec;
+                    SetReaderDeviceInstance(fakeProvider);
+
+                    await viewModel.CreateAppCommand.ExecuteAsync(null);
+
+                    Assert.Null(fakeProvider.LastAuthKey);
+                    Assert.Equal(viewModel.DesfireMasterKeyCurrent, fakeProvider.LastCreateApplicationKey);
+                    Assert.Equal(1, fakeProvider.CreateApplicationCalls);
+                }
+                finally
+                {
+                    ReaderDevice.Reader = originalReader;
+                    SetReaderDeviceInstance(originalInstance);
+                }
+            });
+        }
+
         [Theory]
         [InlineData("0", "0", AccessCondition_MifareDesfireAppCreation.ChangeKeyUsingMK, false)]
         [InlineData("0", "1", AccessCondition_MifareDesfireAppCreation.ChangeKeyUsingMK, false)]
@@ -708,6 +779,10 @@ namespace RFiDGear.Tests
             public string LastWriteKey { get; private set; }
             public DESFireKeyType LastWriteKeyType { get; private set; }
             public int LastWriteKeyNumber { get; private set; }
+            public string LastCreateFileKey { get; private set; }
+            public int CreateFileCalls { get; private set; }
+            public string LastCreateApplicationKey { get; private set; }
+            public int CreateApplicationCalls { get; private set; }
 
             public override Task<ERROR> AuthToMifareDesfireApplication(string _applicationMasterKey, DESFireKeyType _keyType, int _keyNumber, int _appID = 0)
             {
@@ -736,6 +811,28 @@ namespace RFiDGear.Tests
                 LastWriteKeyType = _keyTypeAppWriteKey;
                 LastWriteKeyNumber = _writeKeyNo;
                 return Task.FromResult(ERROR.NoError);
+            }
+
+            public override Task<ERROR> CreateMifareDesfireFile(string _appMasterKey, DESFireKeyType _keyTypeAppMasterKey,
+                FileType_MifareDesfireFileType _fileType, DESFireAccessRights _accessRights, EncryptionMode _encMode,
+                int _appID, int _fileNo, int _fileSize, int _minValue = 0, int _maxValue = 1000,
+                int _initValue = 0, bool _isValueLimited = false, int _maxNbOfRecords = 100)
+            {
+                LastCreateFileKey = _appMasterKey;
+                CreateFileCalls++;
+                return Task.FromResult(ERROR.NoError);
+            }
+
+            public override Task<OperationResult> CreateMifareDesfireApplication(string _piccMasterKey,
+                DESFireKeySettings _keySettingsTarget, DESFireKeyType _keyTypePiccMasterKey,
+                DESFireKeyType _keyTypeTargetApplication, int _maxNbKeys, int _appID,
+                bool authenticateToPICCFirst = true)
+            {
+                LastCreateApplicationKey = _piccMasterKey;
+                CreateApplicationCalls++;
+                return Task.FromResult(OperationResult.Success(
+                    operation: nameof(CreateMifareDesfireApplication),
+                    wasAuthenticated: authenticateToPICCFirst));
             }
         }
 

--- a/RFiDGear.Tests/StartupArgumentProcessorTests.cs
+++ b/RFiDGear.Tests/StartupArgumentProcessorTests.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Threading.Tasks;
 using RFiDGear.Infrastructure.FileAccess;
+using RFiDGear.Infrastructure;
 using RFiDGear.Models;
 using RFiDGear.Services;
 using RFiDGear.Services.Interfaces;
@@ -56,6 +57,51 @@ namespace RFiDGear.Tests
             finally
             {
                 File.Delete(tempProjectFile);
+            }
+        }
+
+        [Fact]
+        public async Task AutorunBootstrap_AppliesPersistedReaderProviderBeforeExecution()
+        {
+            var tempSettingsDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(tempSettingsDirectory);
+            var settingsPath = Path.Combine(tempSettingsDirectory, "settings.xml");
+
+            try
+            {
+                using (var writer = new SettingsReaderWriter(tempSettingsDirectory, loadSettings: false))
+                {
+                    var specification = new DefaultSpecification(true)
+                    {
+                        DefaultReaderProvider = ReaderTypes.Elatec,
+                        AutoLoadProjectOnStart = false
+                    };
+                    writer.SaveSettings(specification, settingsPath);
+                }
+
+                var appliedProvider = ReaderTypes.None;
+                var providerAtRead = ReaderTypes.None;
+                var request = new ProjectBootstrapRequest
+                {
+                    Autorun = true,
+                    SetReaderProvider = value => appliedProvider = value,
+                    ResetTaskStatusAsync = () => Task.CompletedTask,
+                    ReadChipAsync = () =>
+                    {
+                        providerAtRead = appliedProvider;
+                        return Task.CompletedTask;
+                    },
+                    WriteOnceAsync = () => Task.CompletedTask
+                };
+
+                await new ProjectBootstrapper(() => new SettingsReaderWriter(tempSettingsDirectory)).BootstrapAsync(request);
+
+                Assert.Equal(ReaderTypes.Elatec, appliedProvider);
+                Assert.Equal(ReaderTypes.Elatec, providerAtRead);
+            }
+            finally
+            {
+                Directory.Delete(tempSettingsDirectory, true);
             }
         }
 

--- a/RFiDGear/Infrastructure/ReaderProviders/ElatecNetProvider.cs
+++ b/RFiDGear/Infrastructure/ReaderProviders/ElatecNetProvider.cs
@@ -586,7 +586,9 @@ namespace RFiDGear.Infrastructure.ReaderProviders
         protected virtual async Task<ERROR> AuthToMifareDesfireApplicationCore(string _applicationMasterKey, DESFireKeyType _keyType, int _keyNumber, int _appID)
         {
             if (!IsConnected)
+            {
                 return ERROR.TransportError;
+            }
 
             if (readerDevice.IsTWN4LegicReader)
             {

--- a/RFiDGear/Infrastructure/ReaderProviders/ElatecNetProvider.cs
+++ b/RFiDGear/Infrastructure/ReaderProviders/ElatecNetProvider.cs
@@ -480,49 +480,80 @@ namespace RFiDGear.Infrastructure.ReaderProviders
             await _comPortLock.WaitAsync();
             try
             {
-            if (readerDevice.IsConnected)
-            {
-                uint[] appArr;
+                if (!IsConnected)
+                    return ERROR.TransportError;
 
                 DesfireChip ??= new MifareDesfireChipModel();
-
                 DesfireChip.AppList = new List<MifareDesfireAppModel>();
 
+                uint[] appArr = null;
+                Exception lastDirectoryException = null;
+                var maxAttempts = readerDevice.IsTWN4LegicReader ? 3 : 1;
+                for (var attempt = 1; attempt <= maxAttempts; attempt++)
+                {
+                    try
+                    {
+                        // ELATEC's TWN4 LEGIC flow reads the directory directly after SearchTag.
+                        // Selecting PICC here is redundant and intermittently returns AccessDenied.
+                        var tag = await readerDevice.SearchTagAsync();
+                        if (readerDevice.IsTWN4LegicReader && tag == null)
+                            throw new InvalidOperationException("SearchTag did not return a tag.");
+                        if (!readerDevice.IsTWN4LegicReader)
+                            await readerDevice.MifareDesfire_SelectApplicationAsync(0);
+                        appArr = await readerDevice.MifareDesfire_GetAppIDsAsync();
+                        lastDirectoryException = null;
+                        break;
+                    }
+                    catch (Exception e)
+                    {
+                        lastDirectoryException = e;
+                        if (attempt < maxAttempts)
+                        {
+                            Log.ForContext<ElatecNetProvider>().Warning(e,
+                                "Elatec DESFire directory listing attempt {Attempt}/{MaxAttempts} failed; retrying SearchTag/GetAppIDs.",
+                                attempt, maxAttempts);
+                            await Task.Delay(100);
+                        }
+                    }
+                }
+
+                if (lastDirectoryException != null)
+                {
+                    Log.ForContext<ElatecNetProvider>().Error(lastDirectoryException,
+                        "Elatec DESFire directory listing failed after {MaxAttempts} attempts.", maxAttempts);
+                    return ERROR.PermissionDenied;
+                }
+
+                if (appArr != null)
+                {
+                    foreach (var appid in appArr)
+                        DesfireChip.AppList.Add(new MifareDesfireAppModel(appid));
+                }
+
+                // TWN4 LEGIC rejects this optional metadata call intermittently even
+                // though the directory and all card operations are valid. Do not emit
+                // a false operational failure for information the task engine does not use.
+                if (readerDevice.IsTWN4LegicReader)
+                {
+                    DesfireChip.FreeMemory = 0;
+                    return ERROR.NoError;
+                }
+
+                // On other ELATEC readers, re-establish PICC context for the optional lookup.
                 try
                 {
                     await readerDevice.SearchTagAsync();
                     await readerDevice.MifareDesfire_SelectApplicationAsync(0);
                     DesfireChip.FreeMemory = await readerDevice.MifareDesfire_GetFreeMemoryAsync();
                 }
-                catch
+                catch (Exception e)
                 {
                     DesfireChip.FreeMemory = 0;
-                }
-
-                try
-                {
-                    appArr = await readerDevice.MifareDesfire_GetAppIDsAsync();
-
-                    if (appArr != null)
-                    {
-                        foreach (var appid in appArr)
-                        {
-                            DesfireChip.AppList.Add(new MifareDesfireAppModel(appid));
-                        }
-                    }
-                }
-                catch
-                {
-                    return ERROR.AuthFailure;
+                    Log.ForContext<ElatecNetProvider>().Warning(e,
+                        "Elatec DESFire free-memory metadata lookup failed; directory listing remains valid.");
                 }
 
                 return ERROR.NoError;
-            }
-
-            else
-            {
-                return ERROR.TransportError;
-            }
             }
             finally
             {
@@ -546,37 +577,74 @@ namespace RFiDGear.Infrastructure.ReaderProviders
 
         protected virtual async Task<ERROR> AuthToMifareDesfireApplicationCore(string _applicationMasterKey, DESFireKeyType _keyType, int _keyNumber, int _appID)
         {
-            if (readerDevice.IsConnected)
+            if (!IsConnected)
+                return ERROR.TransportError;
+
+            if (readerDevice.IsTWN4LegicReader)
             {
-                if (readerDevice.IsTWN4LegicReader)
+                Exception lastSelectException = null;
+                for (var attempt = 1; attempt <= 3; attempt++)
                 {
                     try
                     {
-                        await readerDevice.SearchTagAsync();
+                        var tag = await readerDevice.SearchTagAsync();
+                        if (tag == null)
+                            throw new InvalidOperationException("SearchTag did not return a tag.");
+
+                        await readerDevice.MifareDesfire_SelectApplicationAsync((uint)_appID);
+                        lastSelectException = null;
+                        break;
                     }
-                    catch { }
+                    catch (Exception e)
+                    {
+                        lastSelectException = e;
+                        if (attempt < 3)
+                        {
+                            Log.ForContext<ElatecNetProvider>().Warning(e,
+                                "Elatec DESFire context establishment attempt {Attempt}/3 failed for AppId {AppId} KeyNo {KeyNumber}; retrying SearchTag/Select.",
+                                attempt, _appID, _keyNumber);
+                            await Task.Delay(100);
+                        }
+                    }
                 }
 
+                if (lastSelectException != null)
+                {
+                    Log.ForContext<ElatecNetProvider>().Error(lastSelectException,
+                        "Elatec DESFire SearchTag/Select failed after 3 attempts for AppId {AppId} KeyNo {KeyNumber}.",
+                        _appID, _keyNumber);
+                    return ERROR.TransportError;
+                }
+            }
+            else
+            {
                 try
                 {
                     await readerDevice.MifareDesfire_SelectApplicationAsync((uint)_appID);
-
-                    await readerDevice.MifareDesfire_AuthenticateAsync(
-                        _applicationMasterKey,
-                        (byte)_keyNumber,
-                        (byte)(int)Enum.Parse(typeof(Elatec.NET.Cards.Mifare.DESFireKeyType), Enum.GetName(typeof(DESFireKeyType), _keyType)),
-                        DESFIRE_AUTHMODE_EV1);
-                    return ERROR.NoError;
                 }
-                catch
+                catch (Exception e)
                 {
-                    return ERROR.AuthFailure;
+                    Log.ForContext<ElatecNetProvider>().Error(e,
+                        "Elatec DESFire SelectApplication failed for AppId {AppId} KeyNo {KeyNumber}.", _appID, _keyNumber);
+                    return ERROR.TransportError;
                 }
             }
 
-            else
+            try
             {
-                return ERROR.TransportError;
+                await readerDevice.MifareDesfire_AuthenticateAsync(
+                    _applicationMasterKey,
+                    (byte)_keyNumber,
+                    (byte)(int)Enum.Parse(typeof(Elatec.NET.Cards.Mifare.DESFireKeyType), Enum.GetName(typeof(DESFireKeyType), _keyType)),
+                    DESFIRE_AUTHMODE_EV1);
+                return ERROR.NoError;
+            }
+            catch (Exception e)
+            {
+                Log.ForContext<ElatecNetProvider>().Error(e,
+                    "Elatec DESFire Authenticate failed for AppId {AppId} KeyNo {KeyNumber} KeyType {KeyType}.",
+                    _appID, _keyNumber, _keyType);
+                return ERROR.AuthFailure;
             }
         }
 
@@ -700,37 +768,70 @@ namespace RFiDGear.Infrastructure.ReaderProviders
             await _comPortLock.WaitAsync();
             try
             {
-            if (readerDevice.IsConnected)
-            {
-                if (readerDevice.IsTWN4LegicReader)
+                if (!IsConnected)
+                {
+                    return OperationResult.Failure(
+                        ERROR.TransportError,
+                        "Reader not connected",
+                        operation: nameof(CreateMifareDesfireApplication),
+                        metadata: new Dictionary<string, string>
+                        {
+                            { "ApplicationId", _appID.ToString(CultureInfo.CurrentCulture) },
+                            { "MaxKeys", _maxNbKeys.ToString(CultureInfo.CurrentCulture) }
+                        });
+                }
+
+                var metadata = new Dictionary<string, string>
+                {
+                    { "ApplicationId", _appID.ToString(CultureInfo.CurrentCulture) },
+                    { "MaxKeys", _maxNbKeys.ToString(CultureInfo.CurrentCulture) },
+                    { "AuthenticateToPICCFirst", authenticateToPICCFirst.ToString(CultureInfo.CurrentCulture) }
+                };
+
+                if (authenticateToPICCFirst)
+                {
+                    // Exactly one complete boundary. The caller must not authenticate first.
+                    var authResult = await AuthToMifareDesfireApplicationCore(
+                        _piccMasterKey, _keyTypePiccMasterKey, 0, 0);
+                    if (authResult != ERROR.NoError)
+                    {
+                        return OperationResult.Failure(
+                            authResult,
+                            "PICC authentication failed while creating application",
+                            operation: nameof(CreateMifareDesfireApplication),
+                            wasAuthenticated: false,
+                            metadata: metadata);
+                    }
+                }
+                else
                 {
                     try
                     {
-                        await readerDevice.SearchTagAsync();
+                        if (readerDevice.IsTWN4LegicReader)
+                            await readerDevice.SearchTagAsync();
+                        await readerDevice.MifareDesfire_SelectApplicationAsync(0);
                     }
-                    catch { }
+                    catch (Exception e)
+                    {
+                        Log.ForContext<ElatecNetProvider>().Error(e,
+                            "Elatec DESFire PICC selection failed before unauthenticated CreateApplication for AppId {AppId}.", _appID);
+                        return OperationResult.Failure(
+                            ERROR.TransportError,
+                            "PICC selection failed while creating application",
+                            e.Message,
+                            nameof(CreateMifareDesfireApplication),
+                            false,
+                            metadata);
+                    }
                 }
 
                 try
                 {
-                    await readerDevice.MifareDesfire_SelectApplicationAsync(0);
-
-                    if (authenticateToPICCFirst)
-                    {
-                        await readerDevice.MifareDesfire_AuthenticateAsync(_piccMasterKey, 0, (byte)(int)Enum.Parse(typeof(Elatec.NET.Cards.Mifare.DESFireKeyType), Enum.GetName(typeof(DESFireKeyType), _keyTypePiccMasterKey)), 1);
-                    }
-
                     await readerDevice.MifareDesfire_CreateApplicationAsync(
                                                 (DESFireAppAccessRights)_keySettingsTarget,
                                                 (Elatec.NET.Cards.Mifare.DESFireKeyType)Enum.Parse(typeof(Elatec.NET.Cards.Mifare.DESFireKeyType), Enum.GetName(typeof(DESFireKeyType), _keyTypeTargetApplication)),
                                                 _maxNbKeys,
                                                 _appID);
-                    var metadata = new Dictionary<string, string>
-                    {
-                        { "ApplicationId", _appID.ToString(CultureInfo.CurrentCulture) },
-                        { "MaxKeys", _maxNbKeys.ToString(CultureInfo.CurrentCulture) },
-                        { "AuthenticateToPICCFirst", authenticateToPICCFirst.ToString(CultureInfo.CurrentCulture) }
-                    };
 
                     return OperationResult.Success(
                         operation: nameof(CreateMifareDesfireApplication),
@@ -767,9 +868,11 @@ namespace RFiDGear.Infrastructure.ReaderProviders
                 }
                 catch (Exception e)
                 {
-                    var code = e.Message.Contains("AUTH", StringComparison.InvariantCultureIgnoreCase) ? ERROR.AuthFailure : ERROR.TransportError;
+                    Log.ForContext<ElatecNetProvider>().Error(e,
+                        "Elatec DESFire CreateApplication command failed for AppId {AppId} MaxKeys {MaxKeys}.",
+                        _appID, _maxNbKeys);
                     return OperationResult.Failure(
-                        code,
+                        ERROR.PermissionDenied,
                         "Failed to create application",
                         e.Message,
                         nameof(CreateMifareDesfireApplication),
@@ -780,20 +883,6 @@ namespace RFiDGear.Infrastructure.ReaderProviders
                             { "MaxKeys", _maxNbKeys.ToString(CultureInfo.CurrentCulture) }
                         });
                 }
-            }
-
-            else
-            {
-                return OperationResult.Failure(
-                    ERROR.TransportError,
-                    "Reader not connected",
-                    operation: nameof(CreateMifareDesfireApplication),
-                    metadata: new Dictionary<string, string>
-                    {
-                        { "ApplicationId", _appID.ToString(CultureInfo.CurrentCulture) },
-                        { "MaxKeys", _maxNbKeys.ToString(CultureInfo.CurrentCulture) }
-                    });
-            }
             }
             finally
             {
@@ -1431,9 +1520,12 @@ namespace RFiDGear.Infrastructure.ReaderProviders
                             {
                                 await CreateStdDataFileAsync((byte)_fileNo, _fileType, _encMode, ar, (uint)_fileSize);
                             }
-                            catch
+                            catch (Exception e)
                             {
-                                return ERROR.AuthFailure;
+                                Log.ForContext<ElatecNetProvider>().Error(e,
+                                    "Elatec DESFire CreateStdDataFile failed for AppId {AppId} FileNo {FileNo} Size {FileSize}.",
+                                    _appID, _fileNo, _fileSize);
+                                return ERROR.PermissionDenied;
                             }
 
                             break;
@@ -1443,9 +1535,12 @@ namespace RFiDGear.Infrastructure.ReaderProviders
                             {
                                 await CreateBackupFileAsync((byte)_fileNo, _encMode, ar, (uint)_fileSize);
                             }
-                            catch
+                            catch (Exception e)
                             {
-                                return ERROR.AuthFailure;
+                                Log.ForContext<ElatecNetProvider>().Error(e,
+                                    "Elatec DESFire CreateBackupFile failed for AppId {AppId} FileNo {FileNo} Size {FileSize}.",
+                                    _appID, _fileNo, _fileSize);
+                                return ERROR.PermissionDenied;
                             }
 
                             break;
@@ -1493,6 +1588,22 @@ namespace RFiDGear.Infrastructure.ReaderProviders
                 (Elatec.NET.Cards.Mifare.EncryptionMode)encMode,
                 accessRights,
                 fileSize);
+        }
+
+        protected virtual Task<byte[]> ReadDesfireDataAsync(byte fileNo, int fileSize, EncryptionMode encMode)
+        {
+            return readerDevice.MifareDesfire_ReadDataAsync(
+                fileNo,
+                fileSize,
+                (Elatec.NET.Cards.Mifare.EncryptionMode)encMode);
+        }
+
+        protected virtual Task WriteDesfireDataAsync(byte fileNo, byte[] data, EncryptionMode encMode)
+        {
+            return readerDevice.MifareDesfire_WriteDataAsync(
+                fileNo,
+                data,
+                (Elatec.NET.Cards.Mifare.EncryptionMode)encMode);
         }
 
         protected virtual async Task CreateBackupFileAsync(byte fileNo, EncryptionMode encMode, DESFireFileAccessRights accessRights, uint fileSize)
@@ -1563,30 +1674,20 @@ namespace RFiDGear.Infrastructure.ReaderProviders
             {
                 try
                 {
-                    await readerDevice.MifareDesfire_SelectApplicationAsync((uint)_appID);
+                    // Exactly one complete boundary: SearchTag (TWN4 LEGIC) -> Select -> Authenticate -> Read.
+                    var authResult = await AuthToMifareDesfireApplicationCore(_appReadKey, _keyTypeAppReadKey, _readKeyNo, _appID);
+                    if (authResult != ERROR.NoError)
+                        return authResult;
 
-                    if (await AuthToMifareDesfireApplicationCore(_appReadKey, _keyTypeAppReadKey, _readKeyNo, _appID) == ERROR.NoError)
-                    {
-                        MifareDESFireData = await readerDevice.MifareDesfire_ReadDataAsync((byte)_fileNo, _fileSize, (Elatec.NET.Cards.Mifare.EncryptionMode)_encMode);
-
-                        if (MifareDESFireData != null)
-                        {
-                            return ERROR.NoError;
-                        }
-                        else
-                        {
-                            return ERROR.AuthFailure;
-                        }
-                    }
-                    else
-                    {
-                        return ERROR.AuthFailure;
-                    }
+                    MifareDESFireData = await ReadDesfireDataAsync((byte)_fileNo, _fileSize, _encMode);
+                    return MifareDESFireData != null ? ERROR.NoError : ERROR.Unknown;
                 }
                 catch (Exception e)
                 {
-                    Log.ForContext<ElatecNetProvider>().Error(e, "Elatec operation failed.");
-                    return ERROR.TransportError;
+                    Log.ForContext<ElatecNetProvider>().Error(e,
+                        "Elatec DESFire ReadData failed for AppId {AppId} FileNo {FileNo} Size {FileSize} Mode {Mode}.",
+                        _appID, _fileNo, _fileSize, _encMode);
+                    return ERROR.PermissionDenied;
                 }
             }
             finally
@@ -1605,18 +1706,19 @@ namespace RFiDGear.Infrastructure.ReaderProviders
             {
                 try
                 {
-                    await readerDevice.MifareDesfire_SelectApplicationAsync((uint)_appID);
-
+                    // Exactly one complete boundary: SearchTag (TWN4 LEGIC) -> Select -> Authenticate -> Write.
                     var authResult = await AuthToMifareDesfireApplicationCore(_appWriteKey, _keyTypeAppWriteKey, _writeKeyNo, _appID);
                     if (authResult != ERROR.NoError)
                         return authResult;
 
-                    await readerDevice.MifareDesfire_WriteDataAsync((byte)_fileNo, _data, (Elatec.NET.Cards.Mifare.EncryptionMode)_encMode);
+                    await WriteDesfireDataAsync((byte)_fileNo, _data, _encMode);
                 }
                 catch (Exception e)
                 {
-                    Log.ForContext<ElatecNetProvider>().Error(e, "Elatec operation failed.");
-                    return ERROR.AuthFailure;
+                    Log.ForContext<ElatecNetProvider>().Error(e,
+                        "Elatec DESFire WriteData failed for AppId {AppId} FileNo {FileNo} Size {FileSize} Mode {Mode}.",
+                        _appID, _fileNo, _data?.Length ?? 0, _encMode);
+                    return ERROR.PermissionDenied;
                 }
 
                 return ERROR.NoError;

--- a/RFiDGear/Infrastructure/ReaderProviders/ElatecNetProvider.cs
+++ b/RFiDGear/Infrastructure/ReaderProviders/ElatecNetProvider.cs
@@ -481,7 +481,9 @@ namespace RFiDGear.Infrastructure.ReaderProviders
             try
             {
                 if (!IsConnected)
+                {
                     return ERROR.TransportError;
+                }
 
                 DesfireChip ??= new MifareDesfireChipModel();
                 DesfireChip.AppList = new List<MifareDesfireAppModel>();
@@ -497,9 +499,13 @@ namespace RFiDGear.Infrastructure.ReaderProviders
                         // Selecting PICC here is redundant and intermittently returns AccessDenied.
                         var tag = await readerDevice.SearchTagAsync();
                         if (readerDevice.IsTWN4LegicReader && tag == null)
+                        {
                             throw new InvalidOperationException("SearchTag did not return a tag.");
+                        }
                         if (!readerDevice.IsTWN4LegicReader)
+                        {
                             await readerDevice.MifareDesfire_SelectApplicationAsync(0);
+                        }
                         appArr = await readerDevice.MifareDesfire_GetAppIDsAsync();
                         lastDirectoryException = null;
                         break;
@@ -527,7 +533,9 @@ namespace RFiDGear.Infrastructure.ReaderProviders
                 if (appArr != null)
                 {
                     foreach (var appid in appArr)
+                    {
                         DesfireChip.AppList.Add(new MifareDesfireAppModel(appid));
+                    }
                 }
 
                 // TWN4 LEGIC rejects this optional metadata call intermittently even
@@ -589,7 +597,9 @@ namespace RFiDGear.Infrastructure.ReaderProviders
                     {
                         var tag = await readerDevice.SearchTagAsync();
                         if (tag == null)
+                        {
                             throw new InvalidOperationException("SearchTag did not return a tag.");
+                        }
 
                         await readerDevice.MifareDesfire_SelectApplicationAsync((uint)_appID);
                         lastSelectException = null;
@@ -808,7 +818,9 @@ namespace RFiDGear.Infrastructure.ReaderProviders
                     try
                     {
                         if (readerDevice.IsTWN4LegicReader)
+                        {
                             await readerDevice.SearchTagAsync();
+                        }
                         await readerDevice.MifareDesfire_SelectApplicationAsync(0);
                     }
                     catch (Exception e)

--- a/RFiDGear/Services/Interfaces/IProjectBootstrapper.cs
+++ b/RFiDGear/Services/Interfaces/IProjectBootstrapper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using RFiDGear.Infrastructure;
 
 namespace RFiDGear.Services.Interfaces
 {
@@ -31,6 +32,8 @@ namespace RFiDGear.Services.Interfaces
         public Action<string> UpdateDateTime { get; set; }
 
         public Action<string> SetCurrentReader { get; set; }
+
+        public Action<ReaderTypes> SetReaderProvider { get; set; }
 
         public Action<int> SetReaderPort { get; set; }
 

--- a/RFiDGear/Services/ProjectBootstrapper.cs
+++ b/RFiDGear/Services/ProjectBootstrapper.cs
@@ -14,6 +14,17 @@ namespace RFiDGear.Services
     public class ProjectBootstrapper : IProjectBootstrapper
     {
         private static readonly ILogger Logger = Log.ForContext<ProjectBootstrapper>();
+        private readonly Func<SettingsReaderWriter> settingsFactory;
+
+        public ProjectBootstrapper()
+            : this(() => new SettingsReaderWriter())
+        {
+        }
+
+        public ProjectBootstrapper(Func<SettingsReaderWriter> settingsFactory)
+        {
+            this.settingsFactory = settingsFactory ?? throw new ArgumentNullException(nameof(settingsFactory));
+        }
 
         public async Task BootstrapAsync(ProjectBootstrapRequest request)
         {
@@ -24,7 +35,7 @@ namespace RFiDGear.Services
 
             try
             {
-                using (var settings = new SettingsReaderWriter())
+                using (var settings = settingsFactory())
                 {
                     await settings.ReadSettingsAsync();
 
@@ -33,6 +44,10 @@ namespace RFiDGear.Services
                     request.SetCurrentReader?.Invoke(string.IsNullOrWhiteSpace(settings.DefaultSpecification.DefaultReaderName)
                         ? Enum.GetName(typeof(ReaderTypes), settings.DefaultSpecification.DefaultReaderProvider)
                         : settings.DefaultSpecification.DefaultReaderName);
+
+                    // This is the authoritative settings read immediately before AUTORUN.
+                    // Keep the static provider in sync, not just the UI label.
+                    request.SetReaderProvider?.Invoke(settings.DefaultSpecification.DefaultReaderProvider);
 
                     if (int.TryParse(settings.DefaultSpecification.LastUsedComPort, out var portNumber))
                     {

--- a/RFiDGear/ViewModels/MainWindowViewModel.cs
+++ b/RFiDGear/ViewModels/MainWindowViewModel.cs
@@ -1785,6 +1785,7 @@ namespace RFiDGear.ViewModel
                 WriteOnceAsync = () => OnNewWriteToChipOnceCommand(),
                 UpdateDateTime = value => DateTimeStatusBar = value,
                 SetCurrentReader = value => CurrentReader = value,
+                SetReaderProvider = value => ReaderDevice.Reader = value,
                 SetReaderPort = value => ReaderDevice.PortNumber = value,
                 SetCulture = value => culture = value
             });

--- a/RFiDGear/ViewModels/TaskSetupViewModels/MifareDesfireSetupViewModel.cs
+++ b/RFiDGear/ViewModels/TaskSetupViewModels/MifareDesfireSetupViewModel.cs
@@ -2533,52 +2533,38 @@ namespace RFiDGear.ViewModel.TaskSetupViewModels
 
                     StatusText = string.Format("{0}: {1}\n", DateTime.Now, ResourceLoader.GetResource("textBoxStatusTextBoxDllLoaded"));
 
-                    if (CustomConverter.FormatMifareDesfireKeyStringWithSpacesEachByte(DesfireReadKeyCurrent, SelectedDesfireReadKeyEncryptionType) == KEY_ERROR.NO_ERROR)
+                    if (CustomConverter.FormatMifareDesfireKeyStringWithSpacesEachByte(DesfireReadKeyCurrent, SelectedDesfireReadKeyEncryptionType) == KEY_ERROR.NO_ERROR && IsValidAppNumberCurrent != false)
                     {
-                        var result = await device.AuthToMifareDesfireApplication(
-                                DesfireReadKeyCurrent,
-                                SelectedDesfireReadKeyEncryptionType,
-                                selectedDesfireReadKeyNumberAsInt, AppNumberCurrentAsInt);
+                        // The provider owns the complete DESFire operation boundary:
+                        // SelectApplication -> Authenticate -> ReadData.
+                        var result = await device.ReadMiFareDESFireChipFile(
+                            DesfireReadKeyCurrent,
+                            SelectedDesfireReadKeyEncryptionType,
+                            selectedDesfireReadKeyNumberAsInt,
+                            SelectedDesfireFileCryptoMode,
+                            FileNumberCurrentAsInt,
+                            AppNumberCurrentAsInt,
+                            FileSizeCurrentAsInt);
 
-
-                        if (IsValidAppNumberCurrent != false && result == ERROR.NoError)
+                        if (result == ERROR.NoError)
                         {
-                            StatusText += string.Format("{0}: Successfully Authenticated to App {1}\n", DateTime.Now, AppNumberCurrentAsInt);
+                            FileSizeCurrent = device.MifareDESFireData.Length.ToString();
+                            StatusText += string.Format("{0}: Successfully Read {2} Bytes Data from FileNo: {1} in AppID: {3}\n", DateTime.Now, FileNumberCurrentAsInt, FileSizeCurrentAsInt, AppNumberCurrentAsInt);
 
-                            result = await device.ReadMiFareDESFireChipFile(DesfireReadKeyCurrent, SelectedDesfireReadKeyEncryptionType, selectedDesfireReadKeyNumberAsInt,
-                                                                   SelectedDesfireFileCryptoMode, FileNumberCurrentAsInt, AppNumberCurrentAsInt, FileSizeCurrentAsInt);
-
-                            if (result == ERROR.NoError)
-                            {
-                                FileSizeCurrent = device.MifareDESFireData.Length.ToString();
-
-                                StatusText += string.Format("{0}: Successfully Read {2} Bytes Data from FileNo: {1} in AppID: {3}\n", DateTime.Now, FileNumberCurrentAsInt, FileSizeCurrentAsInt, AppNumberNewAsInt);
-
-                                var fromChipNode = EnsureDesfireDataNode(childNodeViewModelFromChip, FileNumberCurrentAsInt);
-                                var tempNode = EnsureDesfireDataNode(childNodeViewModelTemp, FileNumberCurrentAsInt);
-
-                                fromChipNode.DesfireFile = new MifareDesfireFileModel(device.MifareDESFireData, (byte)FileNumberCurrentAsInt);
-                                tempNode.DesfireFile = new MifareDesfireFileModel(device.MifareDESFireData, (byte)FileNumberCurrentAsInt);
-
-                                CurrentTaskErrorLevel = result;
-
-                                OnPropertyChanged(nameof(ChildNodeViewModelTemp));
-                                OnPropertyChanged(nameof(ChildNodeViewModelFromChip));
-                                SaveReadDataToFile(device.MifareDESFireData);
-                                await UpdateReaderStatusCommand.ExecuteAsync(false);
-                                return;
-                            }
-                            else
-                            {
-                                await SetErrorStatusAsync(result, "{0}: Unable to Read File with FileID: {1}: {2}", DateTime.Now, FileNumberCurrentAsInt, result.ToString());
-                                return;
-                            }
-                        }
-                        else
-                        {
-                            await SetErrorStatusAsync(result, "{0}: Unable to Read File: {1}", DateTime.Now, result.ToString());
+                            var fromChipNode = EnsureDesfireDataNode(childNodeViewModelFromChip, FileNumberCurrentAsInt);
+                            var tempNode = EnsureDesfireDataNode(childNodeViewModelTemp, FileNumberCurrentAsInt);
+                            fromChipNode.DesfireFile = new MifareDesfireFileModel(device.MifareDESFireData, (byte)FileNumberCurrentAsInt);
+                            tempNode.DesfireFile = new MifareDesfireFileModel(device.MifareDESFireData, (byte)FileNumberCurrentAsInt);
+                            CurrentTaskErrorLevel = result;
+                            OnPropertyChanged(nameof(ChildNodeViewModelTemp));
+                            OnPropertyChanged(nameof(ChildNodeViewModelFromChip));
+                            SaveReadDataToFile(device.MifareDESFireData);
+                            await UpdateReaderStatusCommand.ExecuteAsync(false);
                             return;
                         }
+
+                        await SetErrorStatusAsync(result, "{0}: Unable to Read File with FileID: {1}: {2}", DateTime.Now, FileNumberCurrentAsInt, result.ToString());
+                        return;
                     }
                 }
                 else
@@ -2678,63 +2664,52 @@ namespace RFiDGear.ViewModel.TaskSetupViewModels
                 if (device != null)
                 {
                     await UpdateReaderStatusCommand.ExecuteAsync(true);
-
                     StatusText = string.Format("{0}: {1}\n", DateTime.Now, ResourceLoader.GetResource("textBoxStatusTextBoxDllLoaded"));
 
-                    if (CustomConverter.FormatMifareDesfireKeyStringWithSpacesEachByte(DesfireWriteKeyCurrent, SelectedDesfireWriteKeyEncryptionType) == KEY_ERROR.NO_ERROR)
+                    if (CustomConverter.FormatMifareDesfireKeyStringWithSpacesEachByte(DesfireWriteKeyCurrent, SelectedDesfireWriteKeyEncryptionType) == KEY_ERROR.NO_ERROR && IsValidAppNumberCurrent != false)
                     {
-
-                        var result = await device.AuthToMifareDesfireApplication(
-                                                                         DesfireWriteKeyCurrent,
-                                                                         SelectedDesfireWriteKeyEncryptionType,
-                                                                         selectedDesfireWriteKeyNumberAsInt, AppNumberCurrentAsInt);
-
-                        if (IsValidAppNumberCurrent != false && result == ERROR.NoError)
+                        if (!TryGetDesfireWritePayload(out var payload, out var errorMessage))
                         {
-                            StatusText += string.Format("{0}: Successfully Authenticated to App {1}\n", DateTime.Now, AppNumberCurrentAsInt);
-
-                            if (!TryGetDesfireWritePayload(out var payload, out var errorMessage))
-                            {
-                                await SetErrorStatusAsync(ERROR.Unknown, "{0}: Unable to prepare DESFire data payload: {1}\n", DateTime.Now, errorMessage);
-                                return;
-                            }
-
-                            result = await device.WriteMiFareDESFireChipFile(DesfireWriteKeyCurrent, SelectedDesfireWriteKeyEncryptionType, selectedDesfireWriteKeyNumberAsInt,
-                                                                   SelectedDesfireFileCryptoMode, FileNumberCurrentAsInt, AppNumberCurrentAsInt, payload);
-
-                            if (result == ERROR.NoError)
-                            {
-                                StatusText += string.Format("{0}: Successfully Wrote {2} Bytes to FileNo: {1} with Size: {2} in AppID: {3}\n", DateTime.Now, FileNumberCurrentAsInt, GrandChildNodeViewModel.SelectedDataLengthInBytes, AppNumberCurrentAsInt);
-                                await UpdateReaderStatusCommand.ExecuteAsync(false);
-                            }
-
-                            if (result == ERROR.NoError && SelectedDesfireFileType == FileType_MifareDesfireFileType.BackupFile && device.GetType() == typeof(ElatecNetProvider))
-                            {
-                                result = await device.CommitTransactionAsync();
-                            }
-
-                            if (result == ERROR.NoError)
-                            {
-                                if(SelectedDesfireFileType == FileType_MifareDesfireFileType.BackupFile)
-                                {
-                                    StatusText += string.Format("{0}: Commit Successfully FileNo: {1} in AppID: {3}\n", DateTime.Now, FileNumberCurrentAsInt, GrandChildNodeViewModel.SelectedDataLengthInBytes, AppNumberCurrentAsInt);
-                                }
-                                
-                                CurrentTaskErrorLevel = result;
-                                await UpdateReaderStatusCommand.ExecuteAsync(false);
-                                return;
-                            }
-                            else
-                            {
-                                await SetErrorStatusAsync(result, "{0}: Unable to Write Data: {1}\n", DateTime.Now, result.ToString());
-                                return;
-                            }
-                        }
-                        else
-                        {
-                            await SetErrorStatusAsync(result, "{0}: Unable to Write Data: {1}\n", DateTime.Now, result.ToString());
+                            await SetErrorStatusAsync(ERROR.Unknown, "{0}: Unable to prepare DESFire data payload: {1}\n", DateTime.Now, errorMessage);
                             return;
                         }
+
+                        // The provider owns the complete DESFire operation boundary:
+                        // SelectApplication -> Authenticate -> WriteData.
+                        var result = await device.WriteMiFareDESFireChipFile(
+                            DesfireWriteKeyCurrent,
+                            SelectedDesfireWriteKeyEncryptionType,
+                            selectedDesfireWriteKeyNumberAsInt,
+                            SelectedDesfireFileCryptoMode,
+                            FileNumberCurrentAsInt,
+                            AppNumberCurrentAsInt,
+                            payload);
+
+                        if (result == ERROR.NoError)
+                        {
+                            StatusText += string.Format("{0}: Successfully Wrote {2} Bytes to FileNo: {1} with Size: {2} in AppID: {3}\n", DateTime.Now, FileNumberCurrentAsInt, GrandChildNodeViewModel.SelectedDataLengthInBytes, AppNumberCurrentAsInt);
+                            await UpdateReaderStatusCommand.ExecuteAsync(false);
+                        }
+
+                        if (result == ERROR.NoError && SelectedDesfireFileType == FileType_MifareDesfireFileType.BackupFile && device.GetType() == typeof(ElatecNetProvider))
+                        {
+                            result = await device.CommitTransactionAsync();
+                        }
+
+                        if (result == ERROR.NoError)
+                        {
+                            if (SelectedDesfireFileType == FileType_MifareDesfireFileType.BackupFile)
+                            {
+                                StatusText += string.Format("{0}: Commit Successfully FileNo: {1} in AppID: {3}\n", DateTime.Now, FileNumberCurrentAsInt, GrandChildNodeViewModel.SelectedDataLengthInBytes, AppNumberCurrentAsInt);
+                            }
+
+                            CurrentTaskErrorLevel = result;
+                            await UpdateReaderStatusCommand.ExecuteAsync(false);
+                            return;
+                        }
+
+                        await SetErrorStatusAsync(result, "{0}: Unable to Write Data: {1}\n", DateTime.Now, result.ToString());
+                        return;
                     }
                 }
                 else

--- a/RFiDGear/ViewModels/TaskSetupViewModels/MifareDesfireSetupViewModel.cs
+++ b/RFiDGear/ViewModels/TaskSetupViewModels/MifareDesfireSetupViewModel.cs
@@ -2316,11 +2316,6 @@ namespace RFiDGear.ViewModel.TaskSetupViewModels
 
                     if (CustomConverter.FormatMifareDesfireKeyStringWithSpacesEachByte(DesfireMasterKeyCurrent, SelectedDesfireMasterKeyEncryptionTypeCurrent) == KEY_ERROR.NO_ERROR)
                     {
-                        var authResult = await device.AuthToMifareDesfireApplication(
-                                  DesfireMasterKeyCurrent,
-                                  SelectedDesfireMasterKeyEncryptionTypeCurrent,
-                                  0);
-
                         DESFireKeySettings keySettings;
                         keySettings = (DESFireKeySettings)SelectedDesfireAppKeySettingsCreateNewApp;
 
@@ -2329,10 +2324,9 @@ namespace RFiDGear.ViewModel.TaskSetupViewModels
                         keySettings |= IsAllowCreateDelWithoutMKChecked ? (DESFireKeySettings)4 : (DESFireKeySettings)0;
                         keySettings |= IsAllowConfigChangableChecked ? (DESFireKeySettings)8 : (DESFireKeySettings)0;
 
-                        if (IsValidAppNumberNew != false && authResult == ERROR.NoError)
+                        if (IsValidAppNumberNew != false)
                         {
-                            StatusText += string.Format("{0}: Successfully Authenticated to App 0\n", DateTime.Now);
-
+                            // The provider owns SearchTag -> Select PICC -> Authenticate -> CreateApplication.
                             var createResult = await device.CreateMifareDesfireApplication(
                                 DesfireMasterKeyCurrent,
                                 keySettings,
@@ -2341,38 +2335,19 @@ namespace RFiDGear.ViewModel.TaskSetupViewModels
                                 selectedDesfireAppMaxNumberOfKeysAsInt,
                                 AppNumberNewAsInt);
 
-                            if (createResult.Code == ERROR.NoError)
+                            if (createResult.Code == ERROR.AuthFailure)
                             {
-                                StatusText += string.Format("{0}: Successfully Created AppID {1}\n", DateTime.Now, AppNumberNewAsInt);
-                                CurrentTaskErrorLevel = createResult.Code;
-                                SelectedDesfireAppKeyEncryptionTypeCurrent = SelectedDesfireAppKeyEncryptionTypeCreateNewApp;
-                                AppNumberCurrent = AppNumberNew;
-                                await UpdateReaderStatusCommand.ExecuteAsync(false);
-                                return;
+                                // PICC may allow Create/Delete without master-key authentication.
+                                StatusText += string.Format("{0}: PICC auth failed; retrying without authentication.\n", DateTime.Now);
+                                createResult = await device.CreateMifareDesfireApplication(
+                                    DesfireMasterKeyCurrent,
+                                    keySettings,
+                                    SelectedDesfireMasterKeyEncryptionTypeCurrent,
+                                    SelectedDesfireAppKeyEncryptionTypeCreateNewApp,
+                                    selectedDesfireAppMaxNumberOfKeysAsInt,
+                                    AppNumberNewAsInt,
+                                    authenticateToPICCFirst: false);
                             }
-                            else
-                            {
-                                StatusText += string.Format("{0}: Unable to Create App: {1}\n", DateTime.Now, createResult.Message ?? createResult.Code.ToString());
-                                CurrentTaskErrorLevel = createResult.Code;
-                                await UpdateReaderStatusCommand.ExecuteAsync(false);
-                                return;
-                            }
-                        }
-                        else if (IsValidAppNumberNew != false && authResult == ERROR.AuthFailure)
-                        {
-                            // PICC may be configured to allow application creation without master-key
-                            // authentication ("Create/Delete without MK" key-settings bit is set).
-                            // Retry unauthenticated; the card will reject the command if auth is required.
-                            StatusText += string.Format("{0}: PICC auth failed; retrying without authentication.\n", DateTime.Now);
-
-                            var createResult = await device.CreateMifareDesfireApplication(
-                                DesfireMasterKeyCurrent,
-                                keySettings,
-                                SelectedDesfireMasterKeyEncryptionTypeCurrent,
-                                SelectedDesfireAppKeyEncryptionTypeCreateNewApp,
-                                selectedDesfireAppMaxNumberOfKeysAsInt,
-                                AppNumberNewAsInt,
-                                authenticateToPICCFirst: false);
 
                             if (createResult.Code == ERROR.NoError)
                             {
@@ -2386,14 +2361,6 @@ namespace RFiDGear.ViewModel.TaskSetupViewModels
                                 StatusText += string.Format("{0}: Unable to Create App: {1}\n", DateTime.Now, createResult.Message ?? createResult.Code.ToString());
                                 CurrentTaskErrorLevel = createResult.Code;
                             }
-
-                            await UpdateReaderStatusCommand.ExecuteAsync(false);
-                            return;
-                        }
-                        else
-                        {
-                            StatusText += string.Format("{0}: Authentication to PICC failed.\n", DateTime.Now);
-                            CurrentTaskErrorLevel = authResult;
                             await UpdateReaderStatusCommand.ExecuteAsync(false);
                             return;
                         }
@@ -2439,70 +2406,30 @@ namespace RFiDGear.ViewModel.TaskSetupViewModels
 
                     if (CustomConverter.FormatMifareDesfireKeyStringWithSpacesEachByte(DesfireAppKeyCurrent, SelectedDesfireAppKeyEncryptionTypeCurrent) == KEY_ERROR.NO_ERROR && IsValidAppNumberCurrent != false)
                     {
-                        var result = await device.AuthToMifareDesfireApplication(
-                                DesfireAppKeyCurrent,
-                                SelectedDesfireAppKeyEncryptionTypeCurrent,
-                                selectedDesfireAppKeyNumberCurrentAsInt, AppNumberCurrentAsInt);
+                        // The provider owns the complete DESFire operation boundary:
+                        // SearchTag (TWN4 LEGIC) -> Select -> Authenticate -> CreateFile.
+                        var result = await device.CreateMifareDesfireFile(
+                            DesfireAppKeyCurrent,
+                            SelectedDesfireAppKeyEncryptionTypeCurrent,
+                            SelectedDesfireFileType,
+                            accessRights,
+                            SelectedDesfireFileCryptoMode,
+                            AppNumberCurrentAsInt,
+                            FileNumberCurrentAsInt,
+                            FileSizeCurrentAsInt);
 
                         if (result == ERROR.NoError)
                         {
-                            StatusText += string.Format("{0}: Successfully Authenticated to App {1}\n", DateTime.Now, AppNumberCurrentAsInt);
-
-                            result = await device.CreateMifareDesfireFile(
-                               DesfireAppKeyCurrent,
-                               SelectedDesfireAppKeyEncryptionTypeCurrent,
-                               SelectedDesfireFileType,
-                               accessRights,
-                               SelectedDesfireFileCryptoMode,
-                               AppNumberCurrentAsInt,
-                               FileNumberCurrentAsInt,
-                               FileSizeCurrentAsInt);
-
-                            if (result == ERROR.NoError)
-                            {
-                                StatusText += string.Format("{0}: Successfully Created FileNo: {1} with Size: {2} in AppID: {3}\n", DateTime.Now, FileNumberCurrentAsInt, FileSizeCurrentAsInt, AppNumberNewAsInt);
-                                CurrentTaskErrorLevel = result;
-                                await UpdateReaderStatusCommand.ExecuteAsync(false);
-                                return;
-                            }
-                            else
-                            {
-                                StatusText += string.Format("{0}: Unable to Create File: {1}\n", DateTime.Now, result.ToString());
-                                CurrentTaskErrorLevel = result;
-                                await UpdateReaderStatusCommand.ExecuteAsync(false);
-                                return;
-                            }
+                            StatusText += string.Format("{0}: Successfully Created FileNo: {1} with Size: {2} in AppID: {3}\n", DateTime.Now, FileNumberCurrentAsInt, FileSizeCurrentAsInt, AppNumberCurrentAsInt);
+                            CurrentTaskErrorLevel = result;
+                            await UpdateReaderStatusCommand.ExecuteAsync(false);
+                            return;
                         }
 
-                        else
-                        {
-                            StatusText += string.Format("{0}: Unable to Authenticate to App {1}; Try to Continue Anyway...\n", DateTime.Now, AppNumberCurrentAsInt);
-
-                            result = await device.CreateMifareDesfireFile(
-                                  DesfireAppKeyCurrent,
-                                  SelectedDesfireAppKeyEncryptionTypeCurrent,
-                                  SelectedDesfireFileType,
-                                  accessRights,
-                                  SelectedDesfireFileCryptoMode,
-                                  AppNumberCurrentAsInt,
-                                  FileNumberCurrentAsInt,
-                                  FileSizeCurrentAsInt);
-
-                            if (result == ERROR.NoError)
-                            {
-                                StatusText += string.Format("{0}: Successfully Created FileNo: {1} with Size: {2} in AppID: {3}\n", DateTime.Now, FileNumberCurrentAsInt, FileSizeCurrentAsInt, AppNumberNewAsInt);
-                                CurrentTaskErrorLevel = result;
-                                await UpdateReaderStatusCommand.ExecuteAsync(false);
-                                return;
-                            }
-                            else
-                            {
-                                StatusText += string.Format("{0}: Unable to Create File: {1}\n", DateTime.Now, result.ToString());
-                                CurrentTaskErrorLevel = result;
-                                await UpdateReaderStatusCommand.ExecuteAsync(false);
-                                return;
-                            }
-                        }
+                        StatusText += string.Format("{0}: Unable to Create File: {1}\n", DateTime.Now, result.ToString());
+                        CurrentTaskErrorLevel = result;
+                        await UpdateReaderStatusCommand.ExecuteAsync(false);
+                        return;
                     }
                 }
                 else
@@ -3765,6 +3692,18 @@ namespace RFiDGear.ViewModel.TaskSetupViewModels
                             StatusText += string.Format("{0}: Failed. Directory Listing is not allowed and PICC MK is Incorrect.\n", DateTime.Now);
 
                             CurrentTaskErrorLevel = ERROR.AuthFailure;
+                        }
+
+                        else if (IsValidAppNumberCurrent != false && result == ERROR.PermissionDenied)
+                        {
+                            StatusText += string.Format("{0}: Failed. DESFire directory listing was denied or the reader context was invalid.\n", DateTime.Now);
+                            CurrentTaskErrorLevel = ERROR.PermissionDenied;
+                        }
+
+                        else if (IsValidAppNumberCurrent != false && result == ERROR.TransportError)
+                        {
+                            StatusText += string.Format("{0}: Failed. Reader transport was unavailable while listing DESFire applications.\n", DateTime.Now);
+                            CurrentTaskErrorLevel = ERROR.TransportError;
                         }
 
                         // There are no Apps


### PR DESCRIPTION
## Summary

This PR now contains the complete hardware-tested fix for the sequenced DESFire failures reported in #195.

The original change removed redundant ViewModel authentication before `ReadData` and `WriteData`. Hardware tracing subsequently proved that the same split responsibility also affected application/file creation, TWN4 LEGIC context establishment, directory checks, and AUTORUN reader selection.

## Root causes

- ViewModel and provider both owned parts of `SelectApplication -> Authenticate -> operation`, producing duplicated and incorrectly ordered boundaries.
- Some read/write paths selected an application before the TWN4 LEGIC `SearchTag` context existed.
- `CreateApplication` and `CreateFile` performed a separate outer authentication before calling provider methods that authenticate again.
- Transient TWN4 `SearchTag`, `SelectApplication`, and `GetAppIDs` failures had no bounded context rebuild.
- Optional `GetFreeMemory` metadata generated misleading `AccessDenied` failures on TWN4 LEGIC despite valid card operations.
- The late AUTORUN bootstrap reapplied the reader label and port but not the persisted reader provider, allowing execution with `ReaderDevice.Reader == None`.

## Changes

- Make the provider own each complete DESFire operation boundary.
- Remove duplicated outer authentication for CreateApplication, CreateFile, ReadData, and WriteData.
- Remove premature application selection from provider read/write methods.
- Follow the TWN4 LEGIC SDK flow for application listing directly after `SearchTag`.
- Add bounded, logged retries only for safe context prerequisites (`SearchTag`, `SelectApplication`, `GetAppIDs`).
- Never retry state-changing create/write/key operations generically.
- Skip the unreliable optional free-memory lookup on TWN4 LEGIC.
- Distinguish context/transport, authentication, and operation failures in logs without recording key values.
- Reapply the persisted reader provider immediately before AUTORUN.
- Add regression coverage for provider-owned boundaries, error propagation, and AUTORUN provider application.

## Automated validation

On this exact PR branch:

```text
160 passed, 0 failed, 0 skipped
```

The combined hardware diagnostic build with PR #197 logging passed 163/163 tests; its three additional tests belong to PR #197 and are intentionally not included here.

## Hardware validation

Reader: ELATEC TWN4 LEGIC  
Card: disposable DESFire test card  
Payloads: six non-zero diagnostic patterns (14, 32, 640, 256, 96, and 14 bytes)

Final complete cycle:

- format: 1/1 `Successful / NoError`
- mastering: all 27 tasks executed, none skipped
- 24/24 operative tasks `Successful / NoError`
- three expected negative `AppExistCheck / IsNotTrue` prechecks
- zero unexpected task failures
- six immediate readbacks matched byte-for-byte
- six independent readbacks in a fresh process matched byte-for-byte
- zero final `AuthFailure`, `PermissionDenied`, `TransportError`, or `AccessDenied` events

Repeat validation:

- two additional independent fresh-process readbacks: each 6/6 tasks and 6/6 byte matches, zero critical events
- a second destructive format + complete mastering cycle: same result (24 operative successes, three expected prechecks, no skips, 6/6 byte matches, zero critical events)

PR #197 was used only to obtain sanitized per-task evidence during hardware validation and remains a separate change.

Fixes #195
