### PR TITLE
Fix #199: isolate project settings tests from user configuration

### DIFF
--- a/RFiDGear.Tests/MainWindowViewModelTests.cs
+++ b/RFiDGear.Tests/MainWindowViewModelTests.cs
@@ -67,53 +67,51 @@ namespace RFiDGear.Tests
         {
             await StaTestRunner.RunOnStaThreadAsync(async () =>
             {
-                var bootstrapper = new DeferredSettingsBootstrapper();
-                var viewModel = new MainWindowViewModel(
-                    bootstrapper,
-                    new NoopUpdateNotifier(),
-                    new FakeContextMenuBuilder(),
-                    new FakeAppStartupInitializer(),
-                    new FakeTimerFactory(),
-                    new FakeTaskServiceInitializer(),
-                    new FakeMenuInitializer(),
-                    new FakeStartupArgumentProcessor(),
-                    new NoopUpdateScheduler(),
-                    new FakeReaderMonitor(),
-                    new FakeProjectBootstrapper());
-
-                var initializationTask = viewModel.InitializeAsync();
-
-                bootstrapper.Complete(new SettingsBootstrapResult
-                {
-                    CurrentReaderName = "Reader",
-                    DefaultReaderProvider = ReaderTypes.None,
-                    Culture = CultureInfo.InvariantCulture
-                });
-
-                await initializationTask;
-
                 var tempRoot = Path.Combine(Path.GetTempPath(), "RFiDGear.Tests", Guid.NewGuid().ToString("N"));
                 Directory.CreateDirectory(tempRoot);
-
                 var oldProjectPath = Path.Combine(tempRoot, "old.xml");
                 var newProjectPath = Path.Combine(tempRoot, "new.xml");
+                var settingsDirectory = Path.Combine(tempRoot, "settings");
+                var settingsPath = Path.Combine(settingsDirectory, "settings.xml");
                 var originalOldProjectContent = "<Project><ManifestVersion>1.0.0</ManifestVersion></Project>";
                 var originalNewProjectContent = "<Project><ManifestVersion>1.0.0</ManifestVersion></Project>";
                 File.WriteAllText(oldProjectPath, originalOldProjectContent);
                 File.WriteAllText(newProjectPath, originalNewProjectContent);
+                Directory.CreateDirectory(settingsDirectory);
 
-                var projectManager = new ProjectManager();
-                var originalLastUsedPath = string.Empty;
-
-                using (var settings = new SettingsReaderWriter(projectManager.AppDataPath))
+                using (var settings = new SettingsReaderWriter(settingsDirectory, loadSettings: false))
                 {
-                    originalLastUsedPath = settings.DefaultSpecification.LastUsedProjectPath;
+                    settings.DefaultSpecification = new DefaultSpecification(true);
                     settings.DefaultSpecification.LastUsedProjectPath = oldProjectPath;
-                    await settings.SaveSettings();
+                    settings.SaveSettings(settings.DefaultSpecification, settingsPath);
                 }
 
                 try
                 {
+                    var bootstrapper = new DeferredSettingsBootstrapper();
+                    var viewModel = new MainWindowViewModel(
+                        bootstrapper,
+                        new NoopUpdateNotifier(),
+                        new FakeContextMenuBuilder(),
+                        new FakeAppStartupInitializer(),
+                        new FakeTimerFactory(),
+                        new FakeTaskServiceInitializer(),
+                        new FakeMenuInitializer(),
+                        new FakeStartupArgumentProcessor(),
+                        new NoopUpdateScheduler(),
+                        new FakeReaderMonitor(),
+                        new FakeProjectBootstrapper(),
+                        () => new SettingsReaderWriter(settingsDirectory));
+
+                    var initializationTask = viewModel.InitializeAsync();
+                    bootstrapper.Complete(new SettingsBootstrapResult
+                    {
+                        CurrentReaderName = "Reader",
+                        DefaultReaderProvider = ReaderTypes.None,
+                        Culture = CultureInfo.InvariantCulture
+                    });
+                    await initializationTask;
+
                     var method = typeof(MainWindowViewModel).GetMethod(
                         "OpenLastProjectFile",
                         BindingFlags.Instance | BindingFlags.NonPublic,
@@ -133,19 +131,13 @@ namespace RFiDGear.Tests
                     Assert.Equal(originalOldProjectContent, updatedOldProjectContent);
                     Assert.NotEqual(originalNewProjectContent, updatedNewProjectContent);
 
-                    using (var settings = new SettingsReaderWriter(projectManager.AppDataPath))
+                    using (var settings = new SettingsReaderWriter(settingsDirectory))
                     {
                         Assert.Equal(newProjectPath, settings.DefaultSpecification.LastUsedProjectPath);
                     }
                 }
                 finally
                 {
-                    using (var settings = new SettingsReaderWriter(projectManager.AppDataPath))
-                    {
-                        settings.DefaultSpecification.LastUsedProjectPath = originalLastUsedPath;
-                        await settings.SaveSettings();
-                    }
-
                     if (Directory.Exists(tempRoot))
                     {
                         Directory.Delete(tempRoot, recursive: true);

--- a/RFiDGear.Tests/StartupArgumentProcessorTests.cs
+++ b/RFiDGear.Tests/StartupArgumentProcessorTests.cs
@@ -15,6 +15,8 @@ namespace RFiDGear.Tests
         public async Task CustomProjectFileArgument_TriggersOpenProjectEvenWhenAutoLoadDisabled()
         {
             var tempProjectFile = Path.GetTempFileName();
+            var tempSettingsDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(tempSettingsDirectory);
             try
             {
                 var result = new StartupArgumentProcessor().Process(new[]
@@ -23,10 +25,9 @@ namespace RFiDGear.Tests
                     $"CUSTOMPROJECTFILE={tempProjectFile}"
                 });
 
-                var projectManager = new ProjectManager();
-                var settingsPath = projectManager.SettingsPath;
+                var settingsPath = Path.Combine(tempSettingsDirectory, "settings.xml");
 
-                using (var settingsWriter = new SettingsReaderWriter(projectManager.AppDataPath, loadSettings: false))
+                using (var settingsWriter = new SettingsReaderWriter(tempSettingsDirectory, loadSettings: false))
                 {
                     var specification = new DefaultSpecification(true)
                     {
@@ -48,7 +49,8 @@ namespace RFiDGear.Tests
                     }
                 };
 
-                await new ProjectBootstrapper().BootstrapAsync(request);
+                await new ProjectBootstrapper(
+                    () => new SettingsReaderWriter(tempSettingsDirectory)).BootstrapAsync(request);
 
                 Assert.Equal(new FileInfo(tempProjectFile).FullName, result.ProjectFilePath);
                 Assert.Equal(result.ProjectFilePath, openedPath);
@@ -56,6 +58,7 @@ namespace RFiDGear.Tests
             finally
             {
                 File.Delete(tempProjectFile);
+                Directory.Delete(tempSettingsDirectory, recursive: true);
             }
         }
 

--- a/RFiDGear/Services/ProjectBootstrapper.cs
+++ b/RFiDGear/Services/ProjectBootstrapper.cs
@@ -14,6 +14,17 @@ namespace RFiDGear.Services
     public class ProjectBootstrapper : IProjectBootstrapper
     {
         private static readonly ILogger Logger = Log.ForContext<ProjectBootstrapper>();
+        private readonly Func<SettingsReaderWriter> settingsFactory;
+
+        public ProjectBootstrapper()
+            : this(() => new SettingsReaderWriter())
+        {
+        }
+
+        public ProjectBootstrapper(Func<SettingsReaderWriter> settingsFactory)
+        {
+            this.settingsFactory = settingsFactory ?? throw new ArgumentNullException(nameof(settingsFactory));
+        }
 
         public async Task BootstrapAsync(ProjectBootstrapRequest request)
         {
@@ -24,7 +35,7 @@ namespace RFiDGear.Services
 
             try
             {
-                using (var settings = new SettingsReaderWriter())
+                using (var settings = settingsFactory())
                 {
                     await settings.ReadSettingsAsync();
 

--- a/RFiDGear/ViewModels/MainWindowViewModel.cs
+++ b/RFiDGear/ViewModels/MainWindowViewModel.cs
@@ -58,6 +58,7 @@ namespace RFiDGear.ViewModel
         private TaskDialogFactory taskDialogFactory;
         private ITaskExecutionService taskExecutionService;
         private readonly ISettingsBootstrapper settingsBootstrapper;
+        private readonly Func<SettingsReaderWriter> settingsReaderWriterFactory;
         private readonly IUpdateNotifier updateNotifier;
         private readonly IContextMenuBuilder contextMenuBuilder;
         private readonly IStartupArgumentProcessor startupArgumentProcessor;
@@ -117,7 +118,8 @@ namespace RFiDGear.ViewModel
             IStartupArgumentProcessor startupArgumentProcessor,
             IUpdateScheduler updateScheduler,
             IReaderMonitor readerMonitor,
-            IProjectBootstrapper projectBootstrapper)
+            IProjectBootstrapper projectBootstrapper,
+            Func<SettingsReaderWriter> settingsReaderWriterFactory = null)
         {
             this.settingsBootstrapper = settingsBootstrapper ?? throw new ArgumentNullException(nameof(settingsBootstrapper));
             this.updateNotifier = updateNotifier ?? throw new ArgumentNullException(nameof(updateNotifier));
@@ -129,6 +131,7 @@ namespace RFiDGear.ViewModel
             this.updateScheduler = updateScheduler ?? throw new ArgumentNullException(nameof(updateScheduler));
             this.readerMonitor = readerMonitor ?? throw new ArgumentNullException(nameof(readerMonitor));
             this.projectBootstrapper = projectBootstrapper ?? throw new ArgumentNullException(nameof(projectBootstrapper));
+            this.settingsReaderWriterFactory = settingsReaderWriterFactory ?? (() => new SettingsReaderWriter());
 
             if (appStartupInitializer == null)
             {
@@ -306,7 +309,7 @@ namespace RFiDGear.ViewModel
         /// <returns>A task that completes once the project load finishes.</returns>
         private async Task OpenLastProjectFile(string projectFileToUse)
         {
-            using (var settings = new SettingsReaderWriter())
+            using (var settings = settingsReaderWriterFactory())
             {
                 var autoLoadLastUsedDB = settings.DefaultSpecification.AutoLoadProjectOnStart;
                 string lastUsedDBPath;
@@ -1217,7 +1220,7 @@ namespace RFiDGear.ViewModel
             bool autoLoadLastUsedDB;
             string lastUsedDBPath;
 
-            using (var settings = new SettingsReaderWriter())
+            using (var settings = settingsReaderWriterFactory())
             {
                 CurrentReader = string.IsNullOrWhiteSpace(settings.DefaultSpecification.DefaultReaderName)
                     ? Enum.GetName(typeof(ReaderTypes), settings.DefaultSpecification.DefaultReaderProvider)
@@ -1278,7 +1281,7 @@ namespace RFiDGear.ViewModel
         public IAsyncRelayCommand SaveTaskDialogCommand => new AsyncRelayCommand(OnNewSaveTaskDialogCommand);
         private async Task OnNewSaveTaskDialogCommand()
         {
-            using (var settings = new SettingsReaderWriter())
+            using (var settings = settingsReaderWriterFactory())
             {
                 var targetPath = settings.DefaultSpecification.LastUsedProjectPath;
                 if (!IsValidProjectSavePath(targetPath))
@@ -1324,7 +1327,7 @@ namespace RFiDGear.ViewModel
 
             if (mbox.Show(Dialogs) == MessageBoxResult.Yes)
             {
-                using (var settings = new SettingsReaderWriter())
+                using (var settings = settingsReaderWriterFactory())
                 {
                     settings.DefaultSpecification.LastUsedProjectPath = fileName;
                     await settings.SaveSettings();


### PR DESCRIPTION
## Summary

- inject a settings-reader factory into `MainWindowViewModel` for project open/save paths
- inject a settings-reader factory into `ProjectBootstrapper`
- keep the production default unchanged (`new SettingsReaderWriter()`)
- run `SaveProject_UsesProjectPathFromStartupArguments` against a unique temporary settings directory
- run `CustomProjectFileArgument_TriggersOpenProjectEvenWhenAutoLoadDisabled` against its own temporary settings directory
- remove all known test access to the installed user's `%LOCALAPPDATA%\RFiDGear\settings.xml`

## Root cause

Two tests used the real per-user settings file. The MainWindow test restored only `LastUsedProjectPath` from an earlier in-memory object, so it could overwrite unrelated settings changed by the user, including `DefaultReaderProvider`. The startup argument test also wrote directly to the real file and failed when a running RFiDGear process held it.

## Validation

Targeted test:

```text
1 passed, 0 failed
real settings SHA-256 unchanged before/after
```

Full suite on current `master`:

```text
152 passed, 0 failed, 0 skipped
real settings SHA-256 unchanged before/after
```

The injected factories are used only to redirect settings access in tests. Normal application construction retains the existing settings location and behavior.

Fixes #199
